### PR TITLE
x-request-idの追加

### DIFF
--- a/policy_verification/client/verifier.go
+++ b/policy_verification/client/verifier.go
@@ -107,6 +107,31 @@ type token struct {
 	Value     string
 }
 
+type contextKey struct{}
+
+// WithRequestID x-request-id を context に保存する（interceptor から呼び出す）。
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, contextKey{}, requestID)
+}
+
+// getRequestID context または gRPC incoming metadata から x-request-id を取得する。
+// context に値がある場合はそちらを優先し、なければ metadata を参照する。
+// どちらにも存在しない場合は空文字を返す。
+func getRequestID(ctx context.Context) string {
+	if v, ok := ctx.Value(contextKey{}).(string); ok && v != "" {
+		return v
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	values := md["x-request-id"]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
 // getToken gRPCメタデータからAuthorizationトークンを取得
 func getToken(ctx context.Context) (*token, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
@@ -166,6 +191,11 @@ func (c *verifierClient) Verify(ctx context.Context, resource, action string) er
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", tok.TokenType+" "+tok.Value) // JWT を Authorization ヘッダで送信
 
+	// x-request-id が存在する場合のみ転送する（生成は行わない）
+	if requestID := getRequestID(ctx); requestID != "" {
+		req.Header.Set("x-request-id", requestID)
+	}
+
 	// --- リクエスト送信 ---------------------------------------------------
 	resp, err := c.httpClient.Do(req)
 
@@ -184,7 +214,8 @@ func (c *verifierClient) Verify(ctx context.Context, resource, action string) er
 		c.logger.Error("failed to read response body", "error", err)
 		respBody = nil
 	}
-	c.logger.Debug("response received", "status", resp.StatusCode)
+	requestID := getRequestID(ctx)
+	c.logger.Debug("response received", "status", resp.StatusCode, "x-request-id", requestID)
 
 	// レスポンスボディは常にフルで出力せず、エラー時のみかつ長さを制限してログに出す。
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -193,7 +224,7 @@ func (c *verifierClient) Verify(ctx context.Context, resource, action string) er
 		if len(logBody) > maxLoggedBodySize {
 			logBody = logBody[:maxLoggedBodySize]
 		}
-		c.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody))
+		c.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 	}
 	// --- ステータスコードに基づく判定 -------------------------------------
 	// 2xx 系は成功として扱う。

--- a/policy_verification/endpoint/endpoint.go
+++ b/policy_verification/endpoint/endpoint.go
@@ -1,0 +1,36 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endpoint
+
+import "context"
+
+// VerifierEndpoint はポリシー検証を行うエンドポイントのインターフェース。
+// 実装は REST、gRPC など複数想定されるが、現状は REST のみ。
+type VerifierEndpoint interface {
+	Verify(ctx context.Context, resource, action string) error
+}
+
+type contextKey struct{}
+
+// WithRequestID x-request-id を context に保存する（interceptor から呼び出す）。
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, contextKey{}, requestID)
+}
+
+// RequestIDFromContext context から x-request-id を取得する。
+func RequestIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(contextKey{}).(string)
+	return v
+}

--- a/policy_verification/endpoint/logger.go
+++ b/policy_verification/endpoint/logger.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package endpoint
 
 import (
 	"log/slog"
-	"os"
+
+	"github.com/o3co/grpc.authz/policy_verification/internal"
 )
 
 func newLogger(level slog.Level) *slog.Logger {
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+	return internal.NewLogger(level)
 }

--- a/policy_verification/endpoint/rest_o3_policy_verifier.go
+++ b/policy_verification/endpoint/rest_o3_policy_verifier.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package endpoint
 
 import (
 	"bytes"
@@ -24,54 +24,58 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
-// VerifierClient 認可チェックを行うクライアント
-type VerifierClient interface {
-	Verify(ctx context.Context, resource, action string) error
+const defaultMaxResponseBodySize int64 = 1024 * 1024 // 1MB
+const defaultTimeout = 10 * time.Second
+
+// Option はo3 REST エンドポイントの設定オプション
+type Option func(*restO3PolicyVerifierEndpoint)
+
+// WithTimeout HTTP クライアントのタイムアウトを設定する。未指定時のデフォルトは 10s。
+func WithTimeout(d time.Duration) Option {
+	if d <= 0 {
+		panic(fmt.Sprintf("timeout must be positive, got %v", d))
+	}
+	return func(e *restO3PolicyVerifierEndpoint) {
+		e.timeout = d
+	}
 }
 
-const defaultMaxResponseBodySize int64 = 1024 * 1024 // 1MB
-
-// Option verifierClient の設定オプション
-type Option func(*verifierClient)
-
-// WithMaxResponseBodySize レスポンスボディの最大読み取りサイズを設定する（バイト単位）
+// WithMaxResponseBodySize レスポンスボディの最大読み取りサイズを設定する（バイト単位）。
 func WithMaxResponseBodySize(size int64) Option {
 	if size <= 0 {
 		panic(fmt.Sprintf("maxResponseBodySize must be positive, got %d", size))
 	}
-	return func(c *verifierClient) {
-		c.maxResponseBodySize = size
+	return func(e *restO3PolicyVerifierEndpoint) {
+		e.maxResponseBodySize = size
 	}
 }
 
 // WithLogLevel ログレベルを指定する。未指定時のデフォルトは slog.LevelError。
 func WithLogLevel(level slog.Level) Option {
-	return func(c *verifierClient) {
-		c.logger = newLogger(level)
+	return func(e *restO3PolicyVerifierEndpoint) {
+		e.logger = newLogger(level)
 	}
 }
 
-// verifierClient 認可クライアントの実装
-type verifierClient struct {
+// restO3PolicyVerifierEndpoint は o3 独自規格の REST 認可サービスへの VerifierEndpoint 実装
+type restO3PolicyVerifierEndpoint struct {
 	httpClient          *http.Client
 	verifyURL           string
+	timeout             time.Duration
 	maxResponseBodySize int64
 	logger              *slog.Logger
 }
 
-// NewVerifierClient 認可クライアントのコンストラクタ
+// NewRESTEndpoint o3 REST 認可エンドポイントのコンストラクタ。
 // baseURL が不正な場合はエラーを返す。
-func NewVerifierClient(httpClient *http.Client, baseURL string, opts ...Option) (VerifierClient, error) {
-	if httpClient == nil {
-		return nil, fmt.Errorf("httpClient must not be nil")
-	}
-
+func NewRESTEndpoint(baseURL string, opts ...Option) (VerifierEndpoint, error) {
 	rawBase := strings.TrimSpace(baseURL)
 	if rawBase == "" {
 		return nil, fmt.Errorf("baseURL must not be empty")
@@ -87,19 +91,20 @@ func NewVerifierClient(httpClient *http.Client, baseURL string, opts ...Option) 
 	}
 
 	base.Path = strings.TrimSuffix(base.Path, "/") + "/verify"
-	verifyURL := base.String()
 
-	c := &verifierClient{
-		httpClient:          httpClient,
-		verifyURL:           verifyURL,
+	e := &restO3PolicyVerifierEndpoint{
+		verifyURL:           base.String(),
+		timeout:             defaultTimeout,
 		maxResponseBodySize: defaultMaxResponseBodySize,
 		logger:              newLogger(slog.LevelError),
 	}
 	for _, opt := range opts {
-		opt(c)
+		opt(e)
 	}
 
-	return c, nil
+	e.httpClient = &http.Client{Timeout: e.timeout}
+
+	return e, nil
 }
 
 type token struct {
@@ -107,142 +112,112 @@ type token struct {
 	Value     string
 }
 
-type contextKey struct{}
+// getToken gRPC incoming metadata から Authorization トークンを取得する。
+func getToken(ctx context.Context) (*token, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no metadata found in context")
+	}
 
-// WithRequestID x-request-id を context に保存する（interceptor から呼び出す）。
-func WithRequestID(ctx context.Context, requestID string) context.Context {
-	return context.WithValue(ctx, contextKey{}, requestID)
+	values := md["authorization"]
+	if len(values) == 0 {
+		return nil, fmt.Errorf("no authorization header found")
+	}
+
+	parts := strings.Fields(values[0])
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid authorization header format")
+	}
+
+	return &token{TokenType: parts[0], Value: parts[1]}, nil
 }
 
 // getRequestID context または gRPC incoming metadata から x-request-id を取得する。
 // context に値がある場合はそちらを優先し、なければ metadata を参照する。
 // どちらにも存在しない場合は空文字を返す。
 func getRequestID(ctx context.Context) string {
-	if v, ok := ctx.Value(contextKey{}).(string); ok && v != "" {
+	if v := RequestIDFromContext(ctx); v != "" {
 		return v
 	}
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ""
 	}
-	values := md["x-request-id"]
-	if len(values) == 0 {
-		return ""
+	if values := md["x-request-id"]; len(values) > 0 {
+		return values[0]
 	}
-	return values[0]
+	return ""
 }
 
-// getToken gRPCメタデータからAuthorizationトークンを取得
-func getToken(ctx context.Context) (*token, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-
-	if !ok {
-		return nil, fmt.Errorf("no metadata found in context")
-	}
-
-	// "authorization" キーで取得 (全て小文字になる)
-	values := md["authorization"]
-
-	if len(values) == 0 {
-		return nil, fmt.Errorf("no authorization header found")
-	}
-
-	raw := values[0]
-
-	parts := strings.Fields(raw)
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid authorization header format")
-	}
-
-	tokenType := parts[0]
-	tokenValue := parts[1]
-	return &token{TokenType: tokenType, Value: tokenValue}, nil
-}
-
-// Verify 権限チェックを実行
-func (c *verifierClient) Verify(ctx context.Context, resource, action string) error {
+// Verify 権限チェックを実行する。
+func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, action string) error {
 	// --- 認可トークン取得 -------------------------------------------------
 	tok, err := getToken(ctx)
-
 	if err != nil {
 		return status.Errorf(codes.Unauthenticated, "failed to get authorization token: %v", err)
 	}
 
 	// --- リクエストボディ作成 -----------------------------------------------
-	// 認可サーバーへ渡す JSON ボディを作る。
 	reqBody := map[string]string{"resource": resource, "action": action}
 	jsonData, err := json.Marshal(reqBody)
-
 	if err != nil {
-		// JSON マーシャリングに失敗したら内部エラーとして扱う。
 		return status.Errorf(codes.Internal, "failed to marshal request body: %v", err)
 	}
 
 	// --- HTTP リクエスト作成 -----------------------------------------------
 	// Context を紐付けたリクエストを作成することで、呼び出し元のキャンセルやタイムアウトを継承する。
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.verifyURL, bytes.NewReader(jsonData))
-
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.verifyURL, bytes.NewReader(jsonData))
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to create request: %v", err)
 	}
 
-	// 必要なヘッダをセット
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", tok.TokenType+" "+tok.Value) // JWT を Authorization ヘッダで送信
+	req.Header.Set("Authorization", tok.TokenType+" "+tok.Value)
 
-	// x-request-id が存在する場合のみ転送する（生成は行わない）
+	// x-request-id が存在する場合のみ転送する
 	if requestID := getRequestID(ctx); requestID != "" {
 		req.Header.Set("x-request-id", requestID)
 	}
 
 	// --- リクエスト送信 ---------------------------------------------------
-	resp, err := c.httpClient.Do(req)
-
+	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		// ネットワークエラーやタイムアウトなどは内部エラーとして扱う。
 		return status.Errorf(codes.Internal, "request failed: %v", err)
 	}
-
-	// レスポンスボディは必ず Close する（リソースリーク防止）。
 	defer resp.Body.Close()
 
 	// ボディを最大 maxResponseBodySize バイトまで読み出す（メモリ保護）。
-	// 読み取りに失敗した場合は部分データを捨て、空として扱う。
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, c.maxResponseBodySize))
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, e.maxResponseBodySize))
 	if err != nil {
-		c.logger.Error("failed to read response body", "error", err)
+		e.logger.Error("failed to read response body", "error", err)
 		respBody = nil
 	}
-	requestID := getRequestID(ctx)
-	c.logger.Debug("response received", "status", resp.StatusCode, "x-request-id", requestID)
 
-	// レスポンスボディは常にフルで出力せず、エラー時のみかつ長さを制限してログに出す。
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		const maxLoggedBodySize = 1024
-		logBody := respBody
-		if len(logBody) > maxLoggedBodySize {
-			logBody = logBody[:maxLoggedBodySize]
-		}
-		c.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
-	}
+	requestID := getRequestID(ctx)
+	e.logger.Debug("response received", "status", resp.StatusCode, "x-request-id", requestID)
+
 	// --- ステータスコードに基づく判定 -------------------------------------
-	// 2xx 系は成功として扱う。
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
 
-	// 403 は権限不足 → PermissionDenied を返す。
+	const maxLoggedBodySize = 1024
+	logBody := respBody
+	if len(logBody) > maxLoggedBodySize {
+		logBody = logBody[:maxLoggedBodySize]
+	}
+
 	if resp.StatusCode == http.StatusForbidden {
+		e.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 		return status.Error(codes.PermissionDenied, "access denied")
 	}
 
-	// 401 はトークン無効/期限切れ → Unauthenticated を返す。
 	if resp.StatusCode == http.StatusUnauthorized {
+		e.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 		return status.Error(codes.Unauthenticated, "invalid or expired token")
 	}
 
-	// その他は内部エラーとして扱い、レスポンスボディを含めて原因追跡をしやすくする。
-	c.logger.Error("unexpected authorization service response", "status", resp.StatusCode)
+	e.logger.Error("unexpected authorization service response", "status", resp.StatusCode, "x-request-id", requestID)
 	return status.Errorf(codes.Internal, "authorization service error: %d, body: %s", resp.StatusCode, "Failed to verify policy")
 }

--- a/policy_verification/endpoint/rest_o3_policy_verifier.go
+++ b/policy_verification/endpoint/rest_o3_policy_verifier.go
@@ -34,16 +34,25 @@ import (
 const defaultMaxResponseBodySize int64 = 1024 * 1024 // 1MB
 const defaultTimeout = 10 * time.Second
 
+// buildConfig は NewRESTEndpoint の構築時にのみ使用する一時設定。
+// timeout など構築後に不要なフィールドをここで管理することで、
+// restO3PolicyVerifierEndpoint の struct を実行時に必要なフィールドのみに絞る。
+type buildConfig struct {
+	timeout             time.Duration
+	maxResponseBodySize int64
+	logger              *slog.Logger
+}
+
 // Option はo3 REST エンドポイントの設定オプション
-type Option func(*restO3PolicyVerifierEndpoint)
+type Option func(*buildConfig)
 
 // WithTimeout HTTP クライアントのタイムアウトを設定する。未指定時のデフォルトは 10s。
 func WithTimeout(d time.Duration) Option {
 	if d <= 0 {
 		panic(fmt.Sprintf("timeout must be positive, got %v", d))
 	}
-	return func(e *restO3PolicyVerifierEndpoint) {
-		e.timeout = d
+	return func(c *buildConfig) {
+		c.timeout = d
 	}
 }
 
@@ -52,15 +61,15 @@ func WithMaxResponseBodySize(size int64) Option {
 	if size <= 0 {
 		panic(fmt.Sprintf("maxResponseBodySize must be positive, got %d", size))
 	}
-	return func(e *restO3PolicyVerifierEndpoint) {
-		e.maxResponseBodySize = size
+	return func(c *buildConfig) {
+		c.maxResponseBodySize = size
 	}
 }
 
 // WithLogLevel ログレベルを指定する。未指定時のデフォルトは slog.LevelError。
 func WithLogLevel(level slog.Level) Option {
-	return func(e *restO3PolicyVerifierEndpoint) {
-		e.logger = newLogger(level)
+	return func(c *buildConfig) {
+		c.logger = newLogger(level)
 	}
 }
 
@@ -68,7 +77,6 @@ func WithLogLevel(level slog.Level) Option {
 type restO3PolicyVerifierEndpoint struct {
 	httpClient          *http.Client
 	verifyURL           string
-	timeout             time.Duration
 	maxResponseBodySize int64
 	logger              *slog.Logger
 }
@@ -92,19 +100,21 @@ func NewRESTEndpoint(baseURL string, opts ...Option) (VerifierEndpoint, error) {
 
 	base.Path = strings.TrimSuffix(base.Path, "/") + "/verify"
 
-	e := &restO3PolicyVerifierEndpoint{
-		verifyURL:           base.String(),
+	cfg := &buildConfig{
 		timeout:             defaultTimeout,
 		maxResponseBodySize: defaultMaxResponseBodySize,
 		logger:              newLogger(slog.LevelError),
 	}
 	for _, opt := range opts {
-		opt(e)
+		opt(cfg)
 	}
 
-	e.httpClient = &http.Client{Timeout: e.timeout}
-
-	return e, nil
+	return &restO3PolicyVerifierEndpoint{
+		httpClient:          &http.Client{Timeout: cfg.timeout},
+		verifyURL:           base.String(),
+		maxResponseBodySize: cfg.maxResponseBodySize,
+		logger:              cfg.logger,
+	}, nil
 }
 
 type token struct {
@@ -171,12 +181,14 @@ func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, act
 		return status.Errorf(codes.Internal, "failed to create request: %v", err)
 	}
 
+	requestID := getRequestID(ctx)
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", tok.TokenType+" "+tok.Value)
 
 	// x-request-id が存在する場合のみ転送する
-	if requestID := getRequestID(ctx); requestID != "" {
+	if requestID != "" {
 		req.Header.Set("x-request-id", requestID)
 	}
 
@@ -190,11 +202,10 @@ func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, act
 	// ボディを最大 maxResponseBodySize バイトまで読み出す（メモリ保護）。
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, e.maxResponseBodySize))
 	if err != nil {
-		e.logger.Error("failed to read response body", "error", err)
+		e.logger.Error("failed to read response body", "error", err, "x-request-id", requestID)
 		respBody = nil
 	}
 
-	requestID := getRequestID(ctx)
 	e.logger.Debug("response received", "status", resp.StatusCode, "x-request-id", requestID)
 
 	// --- ステータスコードに基づく判定 -------------------------------------
@@ -207,17 +218,15 @@ func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, act
 	if len(logBody) > maxLoggedBodySize {
 		logBody = logBody[:maxLoggedBodySize]
 	}
+	e.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 
 	if resp.StatusCode == http.StatusForbidden {
-		e.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 		return status.Error(codes.PermissionDenied, "access denied")
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		e.logger.Error("error response from authorization server", "status", resp.StatusCode, "body", string(logBody), "x-request-id", requestID)
 		return status.Error(codes.Unauthenticated, "invalid or expired token")
 	}
 
-	e.logger.Error("unexpected authorization service response", "status", resp.StatusCode, "x-request-id", requestID)
-	return status.Errorf(codes.Internal, "authorization service error: %d, body: %s", resp.StatusCode, "Failed to verify policy")
+	return status.Errorf(codes.Internal, "authorization service error: %d", resp.StatusCode)
 }

--- a/policy_verification/interceptor.go
+++ b/policy_verification/interceptor.go
@@ -16,15 +16,47 @@ package policyverification
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
 	"log/slog"
+	"time"
 
 	client "github.com/o3co/grpc.authz/policy_verification/client"
 	policy "github.com/o3co/grpc.authz/protobuf_policy_option"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// generateRequestID x-request-id を生成する。
+// フォーマット: YYYYMMDDHHmmss_<uuid-v4-no-dashes>
+func generateRequestID() string {
+	now := time.Now().UTC()
+	timestamp := now.Format("20060102150405")
+
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	// UUID v4: version bits
+	b[6] = (b[6] & 0x0f) | 0x40
+	// UUID v4: variant bits
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%s_%x", timestamp, b)
+}
+
+// extractOrGenerateRequestID incoming metadata から x-request-id を取得し、
+// 存在しない場合は新たに生成して返す。
+func extractOrGenerateRequestID(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if values := md["x-request-id"]; len(values) > 0 && values[0] != "" {
+			return values[0]
+		}
+	}
+	return generateRequestID()
+}
 
 // config はインターセプターの設定
 type config struct {
@@ -54,7 +86,10 @@ func Interceptor(verifierClient client.VerifierClient, opts ...Option) grpc.Unar
 	log := newLogger(cfg.logLevel)
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		log.Debug("processing method", "method", info.FullMethod)
+		requestID := extractOrGenerateRequestID(ctx)
+		ctx = client.WithRequestID(ctx, requestID)
+
+		log.Debug("processing method", "method", info.FullMethod, "x-request-id", requestID)
 
 		// protobuf_policy_option.Interceptor が実行済みかチェック
 		// 未登録の場合はチェーン設定ミスとして Internal エラーを返す

--- a/policy_verification/interceptor.go
+++ b/policy_verification/interceptor.go
@@ -21,7 +21,7 @@ import (
 	"log/slog"
 	"time"
 
-	client "github.com/o3co/grpc.authz/policy_verification/client"
+	"github.com/o3co/grpc.authz/policy_verification/endpoint"
 	policy "github.com/o3co/grpc.authz/protobuf_policy_option"
 
 	"google.golang.org/grpc"
@@ -74,9 +74,9 @@ func WithLogLevel(level slog.Level) Option {
 }
 
 // Interceptor 認可チェックを行うインターセプター
-func Interceptor(verifierClient client.VerifierClient, opts ...Option) grpc.UnaryServerInterceptor {
-	if verifierClient == nil {
-		panic("verifierClient must not be nil")
+func Interceptor(verifierEndpoint endpoint.VerifierEndpoint, opts ...Option) grpc.UnaryServerInterceptor {
+	if verifierEndpoint == nil {
+		panic("verifierEndpoint must not be nil")
 	}
 
 	cfg := &config{logLevel: slog.LevelError}
@@ -87,7 +87,7 @@ func Interceptor(verifierClient client.VerifierClient, opts ...Option) grpc.Unar
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		requestID := extractOrGenerateRequestID(ctx)
-		ctx = client.WithRequestID(ctx, requestID)
+		ctx = endpoint.WithRequestID(ctx, requestID)
 
 		log.Debug("processing method", "method", info.FullMethod, "x-request-id", requestID)
 
@@ -101,7 +101,6 @@ func Interceptor(verifierClient client.VerifierClient, opts ...Option) grpc.Unar
 
 		// contextから解決済みポリシーメタデータを取得
 		policyData, ok := policy.PolicyFromContext(ctx)
-
 		if !ok {
 			// Interceptor は実行済みだが、このメソッドにポリシー定義がない（認可不要）
 			return handler(ctx, req)
@@ -112,10 +111,9 @@ func Interceptor(verifierClient client.VerifierClient, opts ...Option) grpc.Unar
 
 		log.Debug("verifying authorization", "resource", resource, "action", action)
 
-		// 認可チェック実行（クライアントはstatusエラーを返す設計）
-		if err := verifierClient.Verify(ctx, resource, action); err != nil {
+		// 認可チェック実行（エンドポイントは status エラーを返す設計）
+		if err := verifierEndpoint.Verify(ctx, resource, action); err != nil {
 			log.Error("authorization check failed", "resource", resource, "action", action, "error", err)
-
 			return nil, err
 		}
 

--- a/policy_verification/internal/logger.go
+++ b/policy_verification/internal/logger.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package policyverification
+package internal
 
 import (
 	"log/slog"
-
-	"github.com/o3co/grpc.authz/policy_verification/internal"
+	"os"
 )
 
-func newLogger(level slog.Level) *slog.Logger {
-	return internal.NewLogger(level)
+func NewLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 }


### PR DESCRIPTION
feat: propagate x-request-id from gRPC metadata to policy verifier HTTP call
- Add WithRequestID/getRequestID helpers in client package using context key
- verifierClient.Verify() forwards x-request-id to upstream HTTP request header
- policy_verification.Interceptor extracts x-request-id from incoming gRPC metadata; generates a new one (YYYYMMDDHHmmss_<uuid-v4>) if absent to support no-proxy deployments
- Log x-request-id at interceptor and client boundaries
- Update x-request-id.md spec to reflect no-proxy generation rule

api-chain において、一番始めにRequestを受け付けたレイヤーがIDを発行し、連続性のログ確認に利用される。
ログには、このRequestIdをダンプするようにすることで、Requestユニークのログ集合体を見ることができる。
