### PR TITLE
feat: add buf.yaml for BSR publishing

### DIFF
--- a/protobuf_policy_option/buf.yaml
+++ b/protobuf_policy_option/buf.yaml
@@ -1,0 +1,4 @@
+version: v2
+modules:
+  - path: schema
+    name: buf.build/o3co/grpc-authz-policy-option


### PR DESCRIPTION
## Summary
- Add `buf.yaml` to `protobuf_policy_option` module for Buf Schema Registry publishing
- Module is published as `buf.build/o3co/grpc-authz-policy-option`
- Enables consumers to declare proto dependency via `buf.yaml` deps instead of manual vendor copy

## Test plan
- [x] `buf push` successfully published to BSR
- [x] Verified consumer (poc.service-domains) can resolve dependency and generate code
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)