### PR TITLE
fix: add license headers and document rand.Read safety

### DIFF
--- a/policy_verification/endpoint/example_test.go
+++ b/policy_verification/endpoint/example_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package endpoint_test
 
 import (

--- a/policy_verification/endpointtest/example_test.go
+++ b/policy_verification/endpointtest/example_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package endpointtest_test
 
 import (

--- a/policy_verification/interceptor.go
+++ b/policy_verification/interceptor.go
@@ -37,6 +37,8 @@ func generateRequestID() string {
 	timestamp := now.Format("20060102150405")
 
 	var b [16]byte
+	// crypto/rand.Read always returns len(b) and nil error on supported platforms (Go 1.20+).
+	// It panics only if the OS random source is unavailable, which is unrecoverable.
 	_, _ = rand.Read(b[:])
 	// UUID v4: version bits
 	b[6] = (b[6] & 0x0f) | 0x40

--- a/tests/integration/cedar_test.go
+++ b/tests/integration/cedar_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration
 
 package integration

--- a/tests/integration/opa_test.go
+++ b/tests/integration/opa_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 o3co Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build integration
 
 package integration


### PR DESCRIPTION
## Summary
- Add Apache 2.0 license headers to 4 test files missing them
- Document why `rand.Read` error is safe to ignore (Go 1.20+ guarantee)

Closes #6

## Test plan
- [x] All unit tests pass
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)