### PR TITLE
feat: add token_introspection module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,25 @@ jobs:
         working-directory: request_tracking
         run: go test ./... -count=1
 
+  token-introspection:
+    name: token_introspection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: token_introspection/go.mod
+          cache-dependency-path: token_introspection/go.sum
+
+      - name: vet
+        working-directory: token_introspection
+        run: go vet ./...
+
+      - name: test
+        working-directory: token_introspection
+        run: go test ./... -count=1
+
   policy-verification:
     name: policy_verification
     runs-on: ubuntu-latest

--- a/token_introspection/README.ja.md
+++ b/token_introspection/README.ja.md
@@ -1,0 +1,118 @@
+# token_introspection
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/o3co/grpc.authz/token_introspection.svg)](https://pkg.go.dev/github.com/o3co/grpc.authz/token_introspection)
+
+[English](README.md)
+
+プラグイン可能なイントロスペクションバックエンドを介してクレデンシャルを検証する gRPC サーバーインターセプター。認証スキーム（Bearer、Basic など）によるディスパッチ、ストラテジーチェーン評価、オプションのキャッシュをサポートする。
+
+## インストール
+
+```bash
+go get github.com/o3co/grpc.authz/token_introspection
+```
+
+## 使用方法
+
+### 基本: Bearer + RFC 7662
+
+```go
+import ti "github.com/o3co/grpc.authz/token_introspection"
+
+rfc7662, _ := ti.NewRFC7662Introspector(
+    "http://auth.provider:3000/oauth/introspect",
+)
+
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),
+        ),
+    ),
+    grpc.ChainStreamInterceptor(
+        ti.StreamInterceptor(
+            ti.WithIntrospector(rfc7662),
+        ),
+    ),
+)
+```
+
+### キャッシュ付き
+
+```go
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),
+            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+        ),
+    ),
+)
+```
+
+キャッシュキーは `SHA-256(scheme + ":" + credential)`。全スキームで1つのキャッシュインスタンスを共有する。成功した結果のみキャッシュされ、エラーはキャッシュされない。
+
+### ハンドラーでクレームにアクセスする
+
+```go
+func (s *server) GetPost(ctx context.Context, req *pb.GetPostRequest) (*pb.Post, error) {
+    result := ti.ResultFromContext(ctx)
+    if result != nil {
+        log.Info("user", "subject", result.Subject, "scopes", result.Scopes)
+    }
+    // ...
+}
+```
+
+### リクエスト ID をイントロスペクションエンドポイントに転送する
+
+```go
+import rt "github.com/o3co/grpc.authz/request_tracking"
+
+rfc7662, _ := ti.NewRFC7662Introspector(
+    "http://auth.provider:3000/oauth/introspect",
+    ti.WithRequestIDFunc(rt.RequestIDFromContext),
+)
+```
+
+### 複数ストラテジー（同一スキーム）
+
+```go
+rfc7662, _ := ti.NewRFC7662Introspector(url)
+jwtLocal := NewJWTIntrospector(publicKey) // future
+
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),   // bearer: 1st
+            ti.WithIntrospector(jwtLocal),  // bearer: 2nd (fallthrough)
+        ),
+    ),
+)
+```
+
+ストラテジーチェーンの評価: `codes.Unauthenticated` → 次を試みる; `codes.Internal` → 中断; 成功 → 返す。
+
+### 認可パイプラインと組み合わせる
+
+```go
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        rt.Interceptor(),                        // [1] request tracking (opt-in)
+        ti.Interceptor(                          // [2] credential validation (opt-in)
+            ti.WithIntrospector(rfc7662),
+            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+        ),
+        policyoption.Interceptor(),              // [3] policy resolution
+        policyverification.Interceptor(verifier), // [4] authorization check
+    ),
+)
+```
+
+### パブリック API（認証不要）
+
+`Authorization` ヘッダーのないリクエストはエラーなしで通過する。ハンドラーは `ResultFromContext` から `nil` を受け取る。パブリック/プライベート混在 API をサポートする。
+
+## ライセンス
+
+Apache License 2.0

--- a/token_introspection/README.ja.md
+++ b/token_introspection/README.ja.md
@@ -91,7 +91,7 @@ grpc.NewServer(
 )
 ```
 
-ストラテジーチェーンの評価: `codes.Unauthenticated` → 次を試みる; `codes.Internal` → 中断; 成功 → 返す。
+ストラテジーチェーンの評価: `codes.Unauthenticated` → 次を試みる; それ以外のエラー → 中断; 成功 → 返す。
 
 ### 認可パイプラインと組み合わせる
 

--- a/token_introspection/README.md
+++ b/token_introspection/README.md
@@ -1,0 +1,118 @@
+# token_introspection
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/o3co/grpc.authz/token_introspection.svg)](https://pkg.go.dev/github.com/o3co/grpc.authz/token_introspection)
+
+[日本語](README.ja.md)
+
+gRPC server interceptors for credential validation via pluggable introspection backends. Dispatches by authentication scheme (Bearer, Basic, etc.) with strategy chain evaluation and optional caching.
+
+## Install
+
+```bash
+go get github.com/o3co/grpc.authz/token_introspection
+```
+
+## Usage
+
+### Basic: Bearer + RFC 7662
+
+```go
+import ti "github.com/o3co/grpc.authz/token_introspection"
+
+rfc7662, _ := ti.NewRFC7662Introspector(
+    "http://auth.provider:3000/oauth/introspect",
+)
+
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),
+        ),
+    ),
+    grpc.ChainStreamInterceptor(
+        ti.StreamInterceptor(
+            ti.WithIntrospector(rfc7662),
+        ),
+    ),
+)
+```
+
+### With cache
+
+```go
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),
+            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+        ),
+    ),
+)
+```
+
+Cache key is `SHA-256(scheme + ":" + credential)`. All schemes share one cache instance. Only successful results are cached; errors are not.
+
+### Access claims in handlers
+
+```go
+func (s *server) GetPost(ctx context.Context, req *pb.GetPostRequest) (*pb.Post, error) {
+    result := ti.ResultFromContext(ctx)
+    if result != nil {
+        log.Info("user", "subject", result.Subject, "scopes", result.Scopes)
+    }
+    // ...
+}
+```
+
+### Forward request ID to introspection endpoint
+
+```go
+import rt "github.com/o3co/grpc.authz/request_tracking"
+
+rfc7662, _ := ti.NewRFC7662Introspector(
+    "http://auth.provider:3000/oauth/introspect",
+    ti.WithRequestIDFunc(rt.RequestIDFromContext),
+)
+```
+
+### Multiple strategies (same scheme)
+
+```go
+rfc7662, _ := ti.NewRFC7662Introspector(url)
+jwtLocal := NewJWTIntrospector(publicKey) // future
+
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        ti.Interceptor(
+            ti.WithIntrospector(rfc7662),   // bearer: 1st
+            ti.WithIntrospector(jwtLocal),  // bearer: 2nd (fallthrough)
+        ),
+    ),
+)
+```
+
+Strategy chain evaluation: `codes.Unauthenticated` → try next; `codes.Internal` → abort; success → return.
+
+### With the authorization pipeline
+
+```go
+grpc.NewServer(
+    grpc.ChainUnaryInterceptor(
+        rt.Interceptor(),                        // [1] request tracking (opt-in)
+        ti.Interceptor(                          // [2] credential validation (opt-in)
+            ti.WithIntrospector(rfc7662),
+            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+        ),
+        policyoption.Interceptor(),              // [3] policy resolution
+        policyverification.Interceptor(verifier), // [4] authorization check
+    ),
+)
+```
+
+### Public API (no auth required)
+
+Requests without an `Authorization` header pass through without error. The handler receives `nil` from `ResultFromContext`. This supports mixed public/private APIs.
+
+## License
+
+Apache License 2.0

--- a/token_introspection/README.md
+++ b/token_introspection/README.md
@@ -91,7 +91,7 @@ grpc.NewServer(
 )
 ```
 
-Strategy chain evaluation: `codes.Unauthenticated` → try next; `codes.Internal` → abort; success → return.
+Strategy chain evaluation: `codes.Unauthenticated` → try next; any other error → abort; success → return.
 
 ### With the authorization pipeline
 

--- a/token_introspection/cache.go
+++ b/token_introspection/cache.go
@@ -1,0 +1,62 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"sync"
+	"time"
+)
+
+// Cache is the interface for introspection result caching.
+type Cache interface {
+	Get(key string) (*IntrospectionResult, bool)
+	Set(key string, result *IntrospectionResult)
+}
+
+type cacheEntry struct {
+	result    *IntrospectionResult
+	expiresAt time.Time
+}
+
+type inMemoryCache struct {
+	ttl     time.Duration
+	entries sync.Map
+}
+
+// NewInMemoryCache creates an in-memory cache with the given TTL.
+// Expired entries are lazily evicted on access.
+func NewInMemoryCache(ttl time.Duration) Cache {
+	return &inMemoryCache{ttl: ttl}
+}
+
+func (c *inMemoryCache) Get(key string) (*IntrospectionResult, bool) {
+	v, ok := c.entries.Load(key)
+	if !ok {
+		return nil, false
+	}
+	entry := v.(*cacheEntry)
+	if time.Now().After(entry.expiresAt) {
+		c.entries.Delete(key)
+		return nil, false
+	}
+	return entry.result, true
+}
+
+func (c *inMemoryCache) Set(key string, result *IntrospectionResult) {
+	c.entries.Store(key, &cacheEntry{
+		result:    result,
+		expiresAt: time.Now().Add(c.ttl),
+	})
+}

--- a/token_introspection/cache.go
+++ b/token_introspection/cache.go
@@ -20,6 +20,8 @@ import (
 )
 
 // Cache is the interface for introspection result caching.
+// Implementations must be safe for concurrent use by multiple goroutines,
+// as interceptors are invoked concurrently across RPCs.
 type Cache interface {
 	Get(key string) (*IntrospectionResult, bool)
 	Set(key string, result *IntrospectionResult)
@@ -55,8 +57,14 @@ func (c *inMemoryCache) Get(key string) (*IntrospectionResult, bool) {
 }
 
 func (c *inMemoryCache) Set(key string, result *IntrospectionResult) {
+	expiry := time.Now().Add(c.ttl)
+	// If the token has an explicit expiration earlier than the cache TTL,
+	// use the token expiration to avoid caching beyond token validity.
+	if !result.ExpiresAt.IsZero() && result.ExpiresAt.Before(expiry) {
+		expiry = result.ExpiresAt
+	}
 	c.entries.Store(key, &cacheEntry{
 		result:    result,
-		expiresAt: time.Now().Add(c.ttl),
+		expiresAt: expiry,
 	})
 }

--- a/token_introspection/cache_test.go
+++ b/token_introspection/cache_test.go
@@ -58,6 +58,22 @@ func TestInMemoryCache_Miss(t *testing.T) {
 	}
 }
 
+// Verify that ExpiresAt shorter than TTL bounds the cache entry lifetime.
+func TestInMemoryCache_ExpiresAtBoundsEntry(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Minute)
+	cache.Set("key1", &IntrospectionResult{
+		Subject:   "user-1",
+		ExpiresAt: time.Now().Add(1 * time.Millisecond),
+	})
+
+	time.Sleep(5 * time.Millisecond)
+
+	_, ok := cache.Get("key1")
+	if ok {
+		t.Error("expected cache miss after token ExpiresAt")
+	}
+}
+
 // Verify that keys with different scheme prefixes don't collide.
 func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
 	cache := NewInMemoryCache(1 * time.Minute)

--- a/token_introspection/cache_test.go
+++ b/token_introspection/cache_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"testing"
+	"time"
+)
+
+// Verify basic Set and Get.
+func TestInMemoryCache_SetGet(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Minute)
+	result := &IntrospectionResult{Subject: "user-1"}
+
+	cache.Set("key1", result)
+
+	got, ok := cache.Get("key1")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.Subject != "user-1" {
+		t.Errorf("Subject = %q, want %q", got.Subject, "user-1")
+	}
+}
+
+// Verify that expired entries return a miss.
+func TestInMemoryCache_Expiry(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Millisecond)
+	cache.Set("key1", &IntrospectionResult{Subject: "user-1"})
+
+	time.Sleep(5 * time.Millisecond)
+
+	_, ok := cache.Get("key1")
+	if ok {
+		t.Error("expected cache miss after expiry")
+	}
+}
+
+// Verify that Get returns miss for unknown keys.
+func TestInMemoryCache_Miss(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Minute)
+
+	_, ok := cache.Get("nonexistent")
+	if ok {
+		t.Error("expected cache miss for unknown key")
+	}
+}
+
+// Verify that keys with different scheme prefixes don't collide.
+func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
+	cache := NewInMemoryCache(1 * time.Minute)
+
+	cache.Set("bearer:token-abc", &IntrospectionResult{Subject: "bearer-user"})
+	cache.Set("basic:token-abc", &IntrospectionResult{Subject: "basic-user"})
+
+	got1, ok := cache.Get("bearer:token-abc")
+	if !ok || got1.Subject != "bearer-user" {
+		t.Errorf("bearer entry = %v, want bearer-user", got1)
+	}
+
+	got2, ok := cache.Get("basic:token-abc")
+	if !ok || got2.Subject != "basic-user" {
+		t.Errorf("basic entry = %v, want basic-user", got2)
+	}
+}

--- a/token_introspection/context.go
+++ b/token_introspection/context.go
@@ -1,0 +1,31 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import "context"
+
+type contextKey struct{}
+
+// WithResult stores the introspection result in the context.
+func WithResult(ctx context.Context, result *IntrospectionResult) context.Context {
+	return context.WithValue(ctx, contextKey{}, result)
+}
+
+// ResultFromContext retrieves the introspection result from the context.
+// Returns nil if not set.
+func ResultFromContext(ctx context.Context) *IntrospectionResult {
+	v, _ := ctx.Value(contextKey{}).(*IntrospectionResult)
+	return v
+}

--- a/token_introspection/context_test.go
+++ b/token_introspection/context_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Verify that WithResult stores a result that can be retrieved with ResultFromContext.
+func TestWithResult_RoundTrip(t *testing.T) {
+	result := &IntrospectionResult{
+		Subject:   "user-123",
+		Scopes:    []string{"read", "write"},
+		ExpiresAt: time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		Claims:    map[string]any{"iss": "auth.provider"},
+	}
+	ctx := WithResult(context.Background(), result)
+	got := ResultFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.Subject != "user-123" {
+		t.Errorf("Subject = %q, want %q", got.Subject, "user-123")
+	}
+	if len(got.Scopes) != 2 || got.Scopes[0] != "read" {
+		t.Errorf("Scopes = %v, want [read write]", got.Scopes)
+	}
+}
+
+// Verify that ResultFromContext returns nil when no result is stored.
+func TestResultFromContext_Nil(t *testing.T) {
+	got := ResultFromContext(context.Background())
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/token_introspection/doc.go
+++ b/token_introspection/doc.go
@@ -1,0 +1,40 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tokenintrospection provides gRPC server interceptors for credential
+// validation via pluggable introspection backends.
+//
+// The interceptor dispatches by authentication scheme (Bearer, Basic, etc.) and
+// supports multiple strategies per scheme with fallthrough evaluation. An optional
+// interceptor-level cache avoids redundant backend calls.
+//
+// Usage:
+//
+//	rfc7662, _ := tokenintrospection.NewRFC7662Introspector(
+//	    "http://auth.provider:3000/oauth/introspect",
+//	)
+//
+//	grpc.NewServer(
+//	    grpc.ChainUnaryInterceptor(
+//	        tokenintrospection.Interceptor(
+//	            tokenintrospection.WithIntrospector(rfc7662),
+//	            tokenintrospection.WithCache(tokenintrospection.NewInMemoryCache(30 * time.Second)),
+//	        ),
+//	    ),
+//	)
+//
+// Retrieve the result in handlers:
+//
+//	result := tokenintrospection.ResultFromContext(ctx)
+package tokenintrospection

--- a/token_introspection/go.mod
+++ b/token_introspection/go.mod
@@ -1,0 +1,3 @@
+module github.com/o3co/grpc.authz/token_introspection
+
+go 1.25.5

--- a/token_introspection/go.mod
+++ b/token_introspection/go.mod
@@ -1,3 +1,12 @@
 module github.com/o3co/grpc.authz/token_introspection
 
 go 1.25.5
+
+require (
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/text v0.32.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
+)

--- a/token_introspection/go.mod
+++ b/token_introspection/go.mod
@@ -2,11 +2,12 @@ module github.com/o3co/grpc.authz/token_introspection
 
 go 1.25.5
 
+require google.golang.org/grpc v1.79.3
+
 require (
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )

--- a/token_introspection/go.sum
+++ b/token_introspection/go.sum
@@ -1,0 +1,12 @@
+golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 h1:gRkg/vSppuSQoDjxyiGfN4Upv/h/DQmIR10ZU8dh4Ww=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
+google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/token_introspection/interceptor.go
+++ b/token_introspection/interceptor.go
@@ -57,6 +57,9 @@ func WithMetadataKey(key string) Option {
 // Introspector.Scheme(). Calling this multiple times for the same scheme
 // creates a strategy chain evaluated in registration order.
 func WithIntrospector(introspector Introspector) Option {
+	if introspector == nil {
+		panic("tokenintrospection: WithIntrospector called with nil introspector")
+	}
 	return func(c *config) {
 		scheme := strings.ToLower(introspector.Scheme())
 		c.schemes[scheme] = append(c.schemes[scheme], introspector)
@@ -93,10 +96,14 @@ func cacheKey(scheme, credential string) string {
 // Returns empty strings if the format is invalid.
 func parseAuthorization(value string) (scheme, credential string) {
 	parts := strings.SplitN(value, " ", 2)
-	if len(parts) != 2 || parts[1] == "" {
+	if len(parts) != 2 {
 		return "", ""
 	}
-	return strings.ToLower(parts[0]), parts[1]
+	credential = strings.TrimSpace(parts[1])
+	if credential == "" {
+		return "", ""
+	}
+	return strings.ToLower(parts[0]), credential
 }
 
 // introspect runs the scheme dispatch, cache check, and strategy chain evaluation.

--- a/token_introspection/interceptor.go
+++ b/token_introspection/interceptor.go
@@ -1,0 +1,194 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+type config struct {
+	logLevel    slog.Level
+	metadataKey string
+	// scheme (lowercase) → ordered list of introspectors
+	schemes map[string][]Introspector
+	cache   Cache
+}
+
+// Option configures the token introspection interceptor.
+type Option func(*config)
+
+// WithLogLevel sets the log level. Default is slog.LevelError.
+func WithLogLevel(level slog.Level) Option {
+	return func(c *config) {
+		c.logLevel = level
+	}
+}
+
+// WithMetadataKey sets the gRPC metadata key to extract the credential from.
+// Default is "authorization".
+func WithMetadataKey(key string) Option {
+	return func(c *config) {
+		c.metadataKey = strings.ToLower(key)
+	}
+}
+
+// WithIntrospector registers an Introspector. The scheme is taken from
+// Introspector.Scheme(). Calling this multiple times for the same scheme
+// creates a strategy chain evaluated in registration order.
+func WithIntrospector(introspector Introspector) Option {
+	return func(c *config) {
+		scheme := strings.ToLower(introspector.Scheme())
+		c.schemes[scheme] = append(c.schemes[scheme], introspector)
+	}
+}
+
+// WithCache sets the interceptor-level cache. Cache key is SHA-256(scheme + ":" + credential).
+// Shared across all schemes and introspectors.
+func WithCache(cache Cache) Option {
+	return func(c *config) {
+		c.cache = cache
+	}
+}
+
+func buildConfig(opts []Option) (*config, *slog.Logger) {
+	cfg := &config{
+		logLevel:    slog.LevelError,
+		metadataKey: "authorization",
+		schemes:     make(map[string][]Introspector),
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg, newLogger(cfg.logLevel)
+}
+
+// cacheKey computes the cache key for a scheme + credential pair.
+func cacheKey(scheme, credential string) string {
+	h := sha256.Sum256([]byte(scheme + ":" + credential))
+	return fmt.Sprintf("%x", h)
+}
+
+// parseAuthorization splits "Scheme credential" into (scheme, credential).
+// Returns empty strings if the format is invalid.
+func parseAuthorization(value string) (scheme, credential string) {
+	parts := strings.SplitN(value, " ", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", ""
+	}
+	return strings.ToLower(parts[0]), parts[1]
+}
+
+// introspect runs the scheme dispatch, cache check, and strategy chain evaluation.
+func introspect(ctx context.Context, cfg *config, log *slog.Logger) (context.Context, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx, nil // no metadata = pass through
+	}
+
+	values := md[cfg.metadataKey]
+	if len(values) == 0 || values[0] == "" {
+		return ctx, nil // no authorization = pass through
+	}
+
+	scheme, credential := parseAuthorization(values[0])
+	if scheme == "" || credential == "" {
+		return ctx, status.Error(codes.Unauthenticated, "malformed authorization header")
+	}
+
+	// Cache check
+	if cfg.cache != nil {
+		key := cacheKey(scheme, credential)
+		if result, hit := cfg.cache.Get(key); hit {
+			log.Debug("cache hit", "scheme", scheme)
+			return WithResult(ctx, result), nil
+		}
+	}
+
+	// Find introspectors for this scheme
+	introspectors, ok := cfg.schemes[scheme]
+	if !ok || len(introspectors) == 0 {
+		return ctx, status.Errorf(codes.Unauthenticated, "unsupported authentication scheme: %s", scheme)
+	}
+
+	// Strategy chain evaluation
+	var lastErr error
+	for _, i := range introspectors {
+		result, err := i.Introspect(ctx, credential)
+		if err == nil {
+			// Success — cache and return
+			if cfg.cache != nil {
+				cfg.cache.Set(cacheKey(scheme, credential), result)
+			}
+			log.Debug("introspection succeeded", "scheme", scheme, "subject", result.Subject)
+			return WithResult(ctx, result), nil
+		}
+
+		lastErr = err
+		st, ok := status.FromError(err)
+		if !ok || st.Code() != codes.Unauthenticated {
+			// Non-Unauthenticated error (e.g., Internal) → abort chain
+			log.Error("introspection failed (aborting chain)", "scheme", scheme, "error", err)
+			return ctx, err
+		}
+		// Unauthenticated → try next strategy
+		log.Debug("strategy unauthenticated, trying next", "scheme", scheme)
+	}
+
+	// All strategies returned Unauthenticated
+	return ctx, lastErr
+}
+
+// wrappedStream wraps grpc.ServerStream with an enriched context.
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *wrappedStream) Context() context.Context { return s.ctx }
+
+// Interceptor returns a gRPC UnaryServerInterceptor.
+func Interceptor(opts ...Option) grpc.UnaryServerInterceptor {
+	cfg, log := buildConfig(opts)
+
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx, err := introspect(ctx, cfg, log)
+		if err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// StreamInterceptor returns a gRPC StreamServerInterceptor.
+func StreamInterceptor(opts ...Option) grpc.StreamServerInterceptor {
+	cfg, log := buildConfig(opts)
+
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx, err := introspect(ss.Context(), cfg, log)
+		if err != nil {
+			return err
+		}
+		return handler(srv, &wrappedStream{ServerStream: ss, ctx: ctx})
+	}
+}

--- a/token_introspection/interceptor_test.go
+++ b/token_introspection/interceptor_test.go
@@ -1,0 +1,410 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// mockIntrospector is a test helper that implements Introspector.
+type mockIntrospector struct {
+	scheme string
+	fn     func(ctx context.Context, credential string) (*IntrospectionResult, error)
+}
+
+func (m *mockIntrospector) Scheme() string { return m.scheme }
+func (m *mockIntrospector) Introspect(ctx context.Context, credential string) (*IntrospectionResult, error) {
+	return m.fn(ctx, credential)
+}
+
+func newMockIntrospector(scheme string, fn func(ctx context.Context, credential string) (*IntrospectionResult, error)) *mockIntrospector {
+	return &mockIntrospector{scheme: scheme, fn: fn}
+}
+
+func allowIntrospector(scheme string) *mockIntrospector {
+	return newMockIntrospector(scheme, func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		return &IntrospectionResult{Subject: "test-user", Scopes: []string{"read"}}, nil
+	})
+}
+
+func denyIntrospector(scheme string) *mockIntrospector {
+	return newMockIntrospector(scheme, func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		return nil, status.Error(codes.Unauthenticated, "invalid credential")
+	})
+}
+
+func internalErrorIntrospector(scheme string) *mockIntrospector {
+	return newMockIntrospector(scheme, func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		return nil, status.Error(codes.Internal, "backend down")
+	})
+}
+
+func ctxWithAuth(value string) context.Context {
+	md := metadata.Pairs("authorization", value)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func assertGRPCCode(t *testing.T, err error, wantCode codes.Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error with code %v, got nil", wantCode)
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != wantCode {
+		t.Errorf("code = %v, want %v", st.Code(), wantCode)
+	}
+}
+
+// --- Unary Interceptor ---
+
+// Verify that a valid Bearer token stores the result in context.
+func TestInterceptor_ValidBearer_StoresResult(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	var capturedResult *IntrospectionResult
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		capturedResult = ResultFromContext(ctx)
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("Bearer my-jwt-token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedResult == nil {
+		t.Fatal("expected result in context")
+	}
+	if capturedResult.Subject != "test-user" {
+		t.Errorf("Subject = %q, want %q", capturedResult.Subject, "test-user")
+	}
+}
+
+// Verify that an invalid Bearer token returns Unauthenticated.
+func TestInterceptor_InvalidBearer_ReturnsUnauthenticated(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(denyIntrospector("bearer")))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		t.Error("handler should not be called")
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("Bearer invalid-token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify that missing Authorization passes through without result.
+func TestInterceptor_NoAuth_PassesThrough(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	called := false
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		called = true
+		if ResultFromContext(ctx) != nil {
+			t.Error("expected no result in context for unauthenticated request")
+		}
+		return "ok", nil
+	}
+
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	resp, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("handler was not called")
+	}
+	if resp != "ok" {
+		t.Errorf("resp = %v, want %q", resp, "ok")
+	}
+}
+
+// Verify that an unsupported scheme returns Unauthenticated.
+func TestInterceptor_UnsupportedScheme_ReturnsUnauthenticated(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		t.Error("handler should not be called")
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("ApiKey some-key")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify that scheme matching is case-insensitive.
+func TestInterceptor_SchemeIsCaseInsensitive(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	var capturedResult *IntrospectionResult
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		capturedResult = ResultFromContext(ctx)
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("BEARER my-token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedResult == nil {
+		t.Fatal("expected result in context")
+	}
+}
+
+// Verify strategy chain: first Unauthenticated, second succeeds.
+func TestInterceptor_MultipleStrategySameScheme(t *testing.T) {
+	first := denyIntrospector("bearer")
+	second := allowIntrospector("bearer")
+	interceptor := Interceptor(WithIntrospector(first), WithIntrospector(second))
+
+	var capturedResult *IntrospectionResult
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		capturedResult = ResultFromContext(ctx)
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("Bearer token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedResult == nil {
+		t.Fatal("expected result from second strategy")
+	}
+}
+
+// Verify that Internal error in chain aborts evaluation.
+func TestInterceptor_ChainInternalAborts(t *testing.T) {
+	first := internalErrorIntrospector("bearer")
+	second := allowIntrospector("bearer")
+	interceptor := Interceptor(WithIntrospector(first), WithIntrospector(second))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		t.Error("handler should not be called")
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("Bearer token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	assertGRPCCode(t, err, codes.Internal)
+}
+
+// Verify all strategies Unauthenticated returns Unauthenticated.
+func TestInterceptor_AllStrategiesUnauthenticated(t *testing.T) {
+	first := denyIntrospector("bearer")
+	second := denyIntrospector("bearer")
+	interceptor := Interceptor(WithIntrospector(first), WithIntrospector(second))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		t.Error("handler should not be called")
+		return nil, nil
+	}
+
+	ctx := ctxWithAuth("Bearer token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify cache hit skips introspector call.
+func TestInterceptor_CacheHit(t *testing.T) {
+	callCount := 0
+	introspector := newMockIntrospector("bearer", func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		callCount++
+		return &IntrospectionResult{Subject: "cached-user"}, nil
+	})
+
+	cache := NewInMemoryCache(1 * time.Minute)
+	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
+	ctx := ctxWithAuth("Bearer same-token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+	// First call: cache miss, introspector called
+	_, _ = interceptor(ctx, nil, info, handler)
+	if callCount != 1 {
+		t.Fatalf("expected 1 introspector call, got %d", callCount)
+	}
+
+	// Second call: cache hit, introspector not called
+	_, _ = interceptor(ctx, nil, info, handler)
+	if callCount != 1 {
+		t.Errorf("expected introspector not called on cache hit, got %d calls", callCount)
+	}
+}
+
+// Verify cache miss calls introspector and stores result.
+func TestInterceptor_CacheMiss(t *testing.T) {
+	callCount := 0
+	introspector := newMockIntrospector("bearer", func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		callCount++
+		return &IntrospectionResult{Subject: "user"}, nil
+	})
+
+	cache := NewInMemoryCache(1 * time.Minute)
+	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+	// Different tokens = different cache keys
+	_, _ = interceptor(ctxWithAuth("Bearer token-a"), nil, info, handler)
+	_, _ = interceptor(ctxWithAuth("Bearer token-b"), nil, info, handler)
+	if callCount != 2 {
+		t.Errorf("expected 2 introspector calls for different tokens, got %d", callCount)
+	}
+}
+
+// Verify errors are not cached.
+func TestInterceptor_CacheErrorNotCached(t *testing.T) {
+	callCount := 0
+	introspector := newMockIntrospector("bearer", func(_ context.Context, _ string) (*IntrospectionResult, error) {
+		callCount++
+		return nil, status.Error(codes.Unauthenticated, "invalid")
+	})
+
+	cache := NewInMemoryCache(1 * time.Minute)
+	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
+	ctx := ctxWithAuth("Bearer bad-token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+	_, _ = interceptor(ctx, nil, info, handler)
+	_, _ = interceptor(ctx, nil, info, handler)
+	if callCount != 2 {
+		t.Errorf("expected introspector called each time for errors, got %d", callCount)
+	}
+}
+
+// Verify handler receives enriched context.
+func TestInterceptor_PassesThrough(t *testing.T) {
+	interceptor := Interceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "response", nil
+	}
+
+	ctx := ctxWithAuth("Bearer token")
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	resp, err := interceptor(ctx, nil, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != "response" {
+		t.Errorf("resp = %v, want %q", resp, "response")
+	}
+}
+
+// --- Stream Interceptor ---
+
+type mockServerStream struct {
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context     { return m.ctx }
+func (m *mockServerStream) RecvMsg(interface{}) error     { return nil }
+func (m *mockServerStream) SendMsg(interface{}) error     { return nil }
+func (m *mockServerStream) SetHeader(metadata.MD) error   { return nil }
+func (m *mockServerStream) SendHeader(metadata.MD) error  { return nil }
+func (m *mockServerStream) SetTrailer(metadata.MD)        {}
+
+// Verify stream with valid token.
+func TestStreamInterceptor_ValidToken(t *testing.T) {
+	interceptor := StreamInterceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	md := metadata.Pairs("authorization", "Bearer valid-token")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ss := &mockServerStream{ctx: ctx}
+
+	var capturedResult *IntrospectionResult
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		capturedResult = ResultFromContext(stream.Context())
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Stream"}
+	err := interceptor(nil, ss, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedResult == nil {
+		t.Fatal("expected result in stream context")
+	}
+}
+
+// Verify stream with invalid token.
+func TestStreamInterceptor_InvalidToken(t *testing.T) {
+	interceptor := StreamInterceptor(WithIntrospector(denyIntrospector("bearer")))
+
+	md := metadata.Pairs("authorization", "Bearer invalid")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ss := &mockServerStream{ctx: ctx}
+
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		t.Error("handler should not be called")
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Stream"}
+	err := interceptor(nil, ss, info, handler)
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify stream with no auth passes through.
+func TestStreamInterceptor_NoAuth_PassesThrough(t *testing.T) {
+	interceptor := StreamInterceptor(WithIntrospector(allowIntrospector("bearer")))
+
+	ss := &mockServerStream{ctx: context.Background()}
+
+	called := false
+	handler := func(srv interface{}, stream grpc.ServerStream) error {
+		called = true
+		if ResultFromContext(stream.Context()) != nil {
+			t.Error("expected no result in context")
+		}
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Stream"}
+	err := interceptor(nil, ss, info, handler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("handler was not called")
+	}
+}

--- a/token_introspection/introspector.go
+++ b/token_introspection/introspector.go
@@ -1,0 +1,44 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"context"
+	"time"
+)
+
+// Introspector validates a credential and returns the introspection result.
+// The credential value does not include the scheme prefix (e.g., for Bearer
+// it receives the raw JWT string, not "Bearer <jwt>").
+//
+// Scheme returns the authentication scheme this introspector handles (lowercase,
+// e.g., "bearer", "basic"). The interceptor uses this to match against the
+// Authorization header's scheme.
+//
+// Introspect returns gRPC status errors:
+//   - codes.Unauthenticated: credential is invalid (chain moves to next strategy)
+//   - codes.Internal: backend failure (chain aborts)
+type Introspector interface {
+	Scheme() string
+	Introspect(ctx context.Context, credential string) (*IntrospectionResult, error)
+}
+
+// IntrospectionResult holds validated credential claims.
+type IntrospectionResult struct {
+	Subject   string         // sub — the authenticated user/entity
+	Scopes    []string       // granted scopes
+	ExpiresAt time.Time      // expiration (zero value if not set)
+	Claims    map[string]any // additional claims (aud, iss, client, user, etc.)
+}

--- a/token_introspection/logger.go
+++ b/token_introspection/logger.go
@@ -1,0 +1,24 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"log/slog"
+	"os"
+)
+
+func newLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -1,0 +1,228 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultTimeout             = 10 * time.Second
+	defaultMaxResponseBodySize = 1024 * 1024 // 1MB
+)
+
+type rfc7662Config struct {
+	timeout             time.Duration
+	maxResponseBodySize int64
+	logger              *slog.Logger
+	requestIDFunc       func(context.Context) string
+	requestIDHeaderKey  string
+}
+
+// RFC7662Option configures the RFC 7662 introspection backend.
+type RFC7662Option func(*rfc7662Config)
+
+// WithTimeout sets the HTTP client timeout. Default is 10s.
+func WithTimeout(d time.Duration) RFC7662Option {
+	if d <= 0 {
+		panic(fmt.Sprintf("timeout must be positive, got %v", d))
+	}
+	return func(c *rfc7662Config) {
+		c.timeout = d
+	}
+}
+
+// WithRequestIDFunc sets a function to extract a request ID from the context
+// for forwarding to the introspection endpoint as a header.
+func WithRequestIDFunc(fn func(context.Context) string) RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.requestIDFunc = fn
+	}
+}
+
+// WithRequestIDHeaderKey sets the HTTP header key for the request ID.
+// Default is "x-request-id". Only used when WithRequestIDFunc is also set.
+func WithRequestIDHeaderKey(key string) RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.requestIDHeaderKey = key
+	}
+}
+
+// WithMaxResponseBodySize sets the max bytes to read from the response.
+func WithMaxResponseBodySize(size int64) RFC7662Option {
+	if size <= 0 {
+		panic(fmt.Sprintf("maxResponseBodySize must be positive, got %d", size))
+	}
+	return func(c *rfc7662Config) {
+		c.maxResponseBodySize = size
+	}
+}
+
+// WithRFC7662LogLevel sets the log level for the RFC 7662 backend.
+func WithRFC7662LogLevel(level slog.Level) RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.logger = newLogger(level)
+	}
+}
+
+type rfc7662Introspector struct {
+	httpClient          *http.Client
+	introspectURL       string
+	maxResponseBodySize int64
+	logger              *slog.Logger
+	requestIDFunc       func(context.Context) string
+	requestIDHeaderKey  string
+}
+
+// NewRFC7662Introspector creates an Introspector that calls an RFC 7662 compliant
+// token introspection endpoint. Scheme() returns "bearer".
+func NewRFC7662Introspector(introspectURL string, opts ...RFC7662Option) (Introspector, error) {
+	raw := strings.TrimSpace(introspectURL)
+	if raw == "" {
+		return nil, fmt.Errorf("introspectURL must not be empty")
+	}
+
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		raw = "http://" + raw
+	}
+
+	cfg := &rfc7662Config{
+		timeout:             defaultTimeout,
+		maxResponseBodySize: defaultMaxResponseBodySize,
+		logger:              newLogger(slog.LevelError),
+		requestIDHeaderKey:  "x-request-id",
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &rfc7662Introspector{
+		httpClient:          &http.Client{Timeout: cfg.timeout},
+		introspectURL:       raw,
+		maxResponseBodySize: cfg.maxResponseBodySize,
+		logger:              cfg.logger,
+		requestIDFunc:       cfg.requestIDFunc,
+		requestIDHeaderKey:  cfg.requestIDHeaderKey,
+	}, nil
+}
+
+func (i *rfc7662Introspector) Scheme() string { return "bearer" }
+
+func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string) (*IntrospectionResult, error) {
+	// Build request body
+	reqBody, err := json.Marshal(map[string]string{"token": credential})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to marshal request body: %v", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, i.introspectURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+credential)
+
+	// Forward request ID if configured
+	if i.requestIDFunc != nil {
+		if id := i.requestIDFunc(ctx); id != "" && i.requestIDHeaderKey != "" {
+			req.Header.Set(i.requestIDHeaderKey, id)
+		}
+	}
+
+	// Send request
+	resp, err := i.httpClient.Do(req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "introspection request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, i.maxResponseBodySize))
+	if err != nil {
+		i.logger.Error("failed to read response body", "error", err)
+		respBody = nil
+	}
+
+	// Handle non-2xx
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, status.Error(codes.Unauthenticated, "token rejected by introspection endpoint")
+		}
+		i.logger.Error("introspection endpoint error", "status", resp.StatusCode)
+		return nil, status.Errorf(codes.Internal, "introspection endpoint returned %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var raw map[string]any
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to parse introspection response: %v", err)
+	}
+
+	// Check active
+	active, _ := raw["active"].(bool)
+	if !active {
+		return nil, status.Error(codes.Unauthenticated, "token is not active")
+	}
+
+	// Map claims to IntrospectionResult
+	result := &IntrospectionResult{
+		Claims: make(map[string]any),
+	}
+
+	// Subject
+	if sub, ok := raw["sub"].(string); ok {
+		result.Subject = sub
+	}
+
+	// Scopes
+	if scopesRaw, ok := raw["scopes"]; ok {
+		if arr, ok := scopesRaw.([]any); ok {
+			for _, s := range arr {
+				if str, ok := s.(string); ok {
+					result.Scopes = append(result.Scopes, str)
+				}
+			}
+		}
+	}
+
+	// ExpiresAt
+	if exp, ok := raw["exp"].(float64); ok {
+		result.ExpiresAt = time.Unix(int64(exp), 0).UTC()
+	}
+
+	// Remaining claims (exclude promoted fields)
+	promoted := map[string]bool{"active": true, "sub": true, "scopes": true, "exp": true}
+	for k, v := range raw {
+		if !promoted[k] {
+			result.Claims[k] = v
+		}
+	}
+
+	return result, nil
+}

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -106,7 +106,7 @@ func NewRFC7662Introspector(introspectURL string, opts ...RFC7662Option) (Intros
 	}
 
 	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
-		raw = "http://" + raw
+		raw = "https://" + raw
 	}
 
 	cfg := &rfc7662Config{
@@ -162,11 +162,13 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 	}
 	defer resp.Body.Close()
 
-	// Read response body
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, i.maxResponseBodySize))
+	// Read response body with truncation detection
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, i.maxResponseBodySize+1))
 	if err != nil {
-		i.logger.Error("failed to read response body", "error", err)
-		respBody = nil
+		return nil, status.Errorf(codes.Internal, "failed to read introspection response: %v", err)
+	}
+	if int64(len(respBody)) > i.maxResponseBodySize {
+		return nil, status.Error(codes.Internal, "introspection response body exceeds size limit")
 	}
 
 	// Handle non-2xx

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -200,7 +200,9 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 		result.Subject = sub
 	}
 
-	// Scopes
+	// Scopes: supports both RFC 7662 "scope" (space-separated string) and
+	// "scopes" (JSON array, used by auth.provider). If both are present,
+	// "scopes" takes precedence.
 	if scopesRaw, ok := raw["scopes"]; ok {
 		if arr, ok := scopesRaw.([]any); ok {
 			for _, s := range arr {
@@ -209,6 +211,8 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 				}
 			}
 		}
+	} else if scopeStr, ok := raw["scope"].(string); ok && scopeStr != "" {
+		result.Scopes = strings.Fields(scopeStr)
 	}
 
 	// ExpiresAt
@@ -217,7 +221,7 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 	}
 
 	// Remaining claims (exclude promoted fields)
-	promoted := map[string]bool{"active": true, "sub": true, "scopes": true, "exp": true}
+	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "scopes": true, "exp": true}
 	for k, v := range raw {
 		if !promoted[k] {
 			result.Claims[k] = v

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenintrospection
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+)
+
+// Verify Scheme() returns "bearer".
+func TestRFC7662_Scheme(t *testing.T) {
+	ep, err := NewRFC7662Introspector("http://localhost/oauth/introspect")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.Scheme() != "bearer" {
+		t.Errorf("Scheme() = %q, want %q", ep.Scheme(), "bearer")
+	}
+}
+
+// Verify active=true returns parsed IntrospectionResult.
+func TestRFC7662_ActiveTrue_ReturnsResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active": true,
+			"sub":    "user-42",
+			"scopes": []string{"read", "write"},
+			"exp":    1735689600, // 2025-01-01T00:00:00Z
+			"iss":    "auth.provider",
+		})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	result, err := ep.Introspect(context.Background(), "my-jwt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Subject != "user-42" {
+		t.Errorf("Subject = %q, want %q", result.Subject, "user-42")
+	}
+	if len(result.Scopes) != 2 || result.Scopes[0] != "read" {
+		t.Errorf("Scopes = %v, want [read write]", result.Scopes)
+	}
+	if result.ExpiresAt.IsZero() {
+		t.Error("expected non-zero ExpiresAt")
+	}
+	if result.Claims["iss"] != "auth.provider" {
+		t.Errorf("Claims[iss] = %v, want %q", result.Claims["iss"], "auth.provider")
+	}
+}
+
+// Verify active=false returns Unauthenticated.
+func TestRFC7662_ActiveFalse_ReturnsUnauthenticated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": false})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, err := ep.Introspect(context.Background(), "expired-token")
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify 401 returns Unauthenticated.
+func TestRFC7662_401_ReturnsUnauthenticated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, err := ep.Introspect(context.Background(), "bad-token")
+	assertGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// Verify 500 returns Internal.
+func TestRFC7662_500_ReturnsInternal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, err := ep.Introspect(context.Background(), "token")
+	assertGRPCCode(t, err, codes.Internal)
+}
+
+// Verify claim mapping: sub, scopes, exp go to struct fields; rest to Claims.
+func TestRFC7662_ClaimMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active":  true,
+			"sub":     "user-99",
+			"scopes":  []string{"admin"},
+			"exp":     1735689600,
+			"aud":     "my-app",
+			"client":  map[string]any{"id": "client-1"},
+		})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	result, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Structured fields
+	if result.Subject != "user-99" {
+		t.Errorf("Subject = %q, want %q", result.Subject, "user-99")
+	}
+	wantExp := time.Unix(1735689600, 0).UTC()
+	if !result.ExpiresAt.Equal(wantExp) {
+		t.Errorf("ExpiresAt = %v, want %v", result.ExpiresAt, wantExp)
+	}
+
+	// Claims should contain aud, client but NOT sub, scopes, exp, active
+	if _, ok := result.Claims["sub"]; ok {
+		t.Error("Claims should not contain 'sub' (promoted to Subject)")
+	}
+	if _, ok := result.Claims["scopes"]; ok {
+		t.Error("Claims should not contain 'scopes' (promoted to Scopes)")
+	}
+	if _, ok := result.Claims["exp"]; ok {
+		t.Error("Claims should not contain 'exp' (promoted to ExpiresAt)")
+	}
+	if _, ok := result.Claims["active"]; ok {
+		t.Error("Claims should not contain 'active'")
+	}
+	if result.Claims["aud"] != "my-app" {
+		t.Errorf("Claims[aud] = %v, want %q", result.Claims["aud"], "my-app")
+	}
+}
+
+// Verify request ID is forwarded when WithRequestIDFunc is set.
+func TestRFC7662_RequestIDForwarded(t *testing.T) {
+	var capturedHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("x-request-id")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL,
+		WithRequestIDFunc(func(_ context.Context) string { return "req-id-abc" }),
+	)
+	_, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedHeader != "req-id-abc" {
+		t.Errorf("x-request-id = %q, want %q", capturedHeader, "req-id-abc")
+	}
+}
+
+// Verify no request ID header when func is not set.
+func TestRFC7662_RequestIDNotSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get("x-request-id"); v != "" {
+			t.Errorf("x-request-id should not be set, got %q", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, _ = ep.Introspect(context.Background(), "token")
+}
+
+// Verify custom request ID header key.
+func TestRFC7662_WithRequestIDHeaderKey(t *testing.T) {
+	var capturedHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Trace-Id")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL,
+		WithRequestIDFunc(func(_ context.Context) string { return "trace-xyz" }),
+		WithRequestIDHeaderKey("X-Trace-Id"),
+	)
+	_, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedHeader != "trace-xyz" {
+		t.Errorf("X-Trace-Id = %q, want %q", capturedHeader, "trace-xyz")
+	}
+}
+
+// Verify the request body contains the token.
+func TestRFC7662_RequestBody(t *testing.T) {
+	var body map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+
+	if body["token"] != "my-jwt-token" {
+		t.Errorf("body[token] = %q, want %q", body["token"], "my-jwt-token")
+	}
+}
+
+// Verify Authorization: Bearer <token> is set on the request.
+func TestRFC7662_AuthorizationHeader(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+
+	if capturedAuth != "Bearer my-jwt-token" {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer my-jwt-token")
+	}
+}
+
+// Verify empty URL returns error.
+func TestNewRFC7662Introspector_EmptyURL_ReturnsError(t *testing.T) {
+	_, err := NewRFC7662Introspector("")
+	if err == nil {
+		t.Error("expected error for empty URL")
+	}
+}

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -260,6 +260,56 @@ func TestRFC7662_AuthorizationHeader(t *testing.T) {
 	}
 }
 
+// Verify RFC 7662 "scope" (space-separated string) is parsed into Scopes.
+func TestRFC7662_ScopeString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active": true,
+			"sub":    "user-1",
+			"scope":  "read write admin",
+		})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	result, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Scopes) != 3 || result.Scopes[0] != "read" || result.Scopes[1] != "write" || result.Scopes[2] != "admin" {
+		t.Errorf("Scopes = %v, want [read write admin]", result.Scopes)
+	}
+	if _, ok := result.Claims["scope"]; ok {
+		t.Error("Claims should not contain 'scope' (promoted to Scopes)")
+	}
+}
+
+// Verify "scopes" (array) takes precedence over "scope" (string) when both are present.
+func TestRFC7662_ScopesArrayPrecedence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active": true,
+			"sub":    "user-1",
+			"scope":  "read",
+			"scopes": []string{"write", "admin"},
+		})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	result, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Scopes) != 2 || result.Scopes[0] != "write" || result.Scopes[1] != "admin" {
+		t.Errorf("Scopes = %v, want [write admin] (scopes array should take precedence)", result.Scopes)
+	}
+}
+
 // Verify empty URL returns error.
 func TestNewRFC7662Introspector_EmptyURL_ReturnsError(t *testing.T) {
 	_, err := NewRFC7662Introspector("")


### PR DESCRIPTION
## Summary

- Add `token_introspection` module — scheme-aware gRPC interceptors for credential validation with pluggable backends and caching
- Implements `Introspector` interface, strategy chain evaluation (Unauthenticated → next, Internal → abort), interceptor-level cache with `SHA-256(scheme:credential)` keys
- Initial backend: RFC 7662 token introspection (`NewRFC7662Introspector`), supports both `"scope"` (RFC 7662 string) and `"scopes"` (JSON array)
- No dependencies on other grpc.authz modules (`request_tracking`, `protobuf_policy_option`, `policy_verification`)

## Test plan

- [ ] 35 unit tests pass (`go test ./... -count=1` in `token_introspection/`)
- [ ] `go vet` clean
- [ ] Other modules unaffected (`request_tracking`, `protobuf_policy_option`, `policy_verification` tests pass)
- [ ] CI pipeline added for `token_introspection`

## Follow-up

- InMemoryCache: add max size cap and/or background sweep for expired entries

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)