### PR TITLE
feat: InMemoryCache max entries + background sweep

### DIFF
--- a/token_introspection/README.ja.md
+++ b/token_introspection/README.ja.md
@@ -44,7 +44,7 @@ grpc.NewServer(
     grpc.ChainUnaryInterceptor(
         ti.Interceptor(
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(context.Background(), 30 * time.Second)),
         ),
     ),
 )
@@ -101,7 +101,7 @@ grpc.NewServer(
         rt.Interceptor(),                        // [1] request tracking (opt-in)
         ti.Interceptor(                          // [2] credential validation (opt-in)
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(context.Background(), 30 * time.Second)),
         ),
         policyoption.Interceptor(),              // [3] policy resolution
         policyverification.Interceptor(verifier), // [4] authorization check

--- a/token_introspection/README.ja.md
+++ b/token_introspection/README.ja.md
@@ -44,7 +44,7 @@ grpc.NewServer(
     grpc.ChainUnaryInterceptor(
         ti.Interceptor(
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
         ),
     ),
 )
@@ -101,7 +101,7 @@ grpc.NewServer(
         rt.Interceptor(),                        // [1] request tracking (opt-in)
         ti.Interceptor(                          // [2] credential validation (opt-in)
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
         ),
         policyoption.Interceptor(),              // [3] policy resolution
         policyverification.Interceptor(verifier), // [4] authorization check

--- a/token_introspection/README.md
+++ b/token_introspection/README.md
@@ -44,7 +44,7 @@ grpc.NewServer(
     grpc.ChainUnaryInterceptor(
         ti.Interceptor(
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(context.Background(), 30 * time.Second)),
         ),
     ),
 )
@@ -101,7 +101,7 @@ grpc.NewServer(
         rt.Interceptor(),                        // [1] request tracking (opt-in)
         ti.Interceptor(                          // [2] credential validation (opt-in)
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(context.Background(), 30 * time.Second)),
         ),
         policyoption.Interceptor(),              // [3] policy resolution
         policyverification.Interceptor(verifier), // [4] authorization check

--- a/token_introspection/README.md
+++ b/token_introspection/README.md
@@ -44,7 +44,7 @@ grpc.NewServer(
     grpc.ChainUnaryInterceptor(
         ti.Interceptor(
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
         ),
     ),
 )
@@ -101,7 +101,7 @@ grpc.NewServer(
         rt.Interceptor(),                        // [1] request tracking (opt-in)
         ti.Interceptor(                          // [2] credential validation (opt-in)
             ti.WithIntrospector(rfc7662),
-            ti.WithCache(ti.NewInMemoryCache(30 * time.Second)),
+            ti.WithCache(ti.NewInMemoryCache(ctx, 30 * time.Second)),
         ),
         policyoption.Interceptor(),              // [3] policy resolution
         policyverification.Interceptor(verifier), // [4] authorization check

--- a/token_introspection/cache.go
+++ b/token_introspection/cache.go
@@ -15,6 +15,7 @@
 package tokenintrospection
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -32,15 +33,77 @@ type cacheEntry struct {
 	expiresAt time.Time
 }
 
+type inMemoryCacheConfig struct {
+	maxEntries    int
+	sweepInterval time.Duration
+}
+
+// InMemoryCacheOption configures the in-memory cache.
+type InMemoryCacheOption func(*inMemoryCacheConfig)
+
+// WithMaxEntries sets the maximum number of entries in the cache.
+// When exceeded on Set, the entry with the earliest expiration is evicted.
+// Default: 0 (unlimited).
+func WithMaxEntries(n int) InMemoryCacheOption {
+	return func(c *inMemoryCacheConfig) {
+		c.maxEntries = n
+	}
+}
+
+// WithSweepInterval sets the interval for the background goroutine that
+// removes expired entries. Default: same as TTL.
+func WithSweepInterval(d time.Duration) InMemoryCacheOption {
+	return func(c *inMemoryCacheConfig) {
+		c.sweepInterval = d
+	}
+}
+
 type inMemoryCache struct {
-	ttl     time.Duration
-	entries sync.Map
+	ttl        time.Duration
+	maxEntries int
+	entries    sync.Map
 }
 
 // NewInMemoryCache creates an in-memory cache with the given TTL.
-// Expired entries are lazily evicted on access.
-func NewInMemoryCache(ttl time.Duration) Cache {
-	return &inMemoryCache{ttl: ttl}
+// A background goroutine periodically removes expired entries. It stops
+// when ctx is cancelled.
+func NewInMemoryCache(ctx context.Context, ttl time.Duration, opts ...InMemoryCacheOption) Cache {
+	cfg := &inMemoryCacheConfig{
+		sweepInterval: ttl,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	c := &inMemoryCache{
+		ttl:        ttl,
+		maxEntries: cfg.maxEntries,
+	}
+
+	go c.sweepLoop(ctx, cfg.sweepInterval)
+
+	return c
+}
+
+func (c *inMemoryCache) sweepLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			c.entries.Range(func(key, value any) bool {
+				entry := value.(*cacheEntry)
+				if now.After(entry.expiresAt) {
+					c.entries.Delete(key)
+				}
+				return true
+			})
+		}
+	}
 }
 
 func (c *inMemoryCache) Get(key string) (*IntrospectionResult, bool) {
@@ -63,8 +126,41 @@ func (c *inMemoryCache) Set(key string, result *IntrospectionResult) {
 	if !result.ExpiresAt.IsZero() && result.ExpiresAt.Before(expiry) {
 		expiry = result.ExpiresAt
 	}
+
 	c.entries.Store(key, &cacheEntry{
 		result:    result,
 		expiresAt: expiry,
 	})
+
+	// Evict if over max entries
+	if c.maxEntries > 0 {
+		c.evictIfNeeded()
+	}
+}
+
+func (c *inMemoryCache) evictIfNeeded() {
+	var count int
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+
+	for count > c.maxEntries {
+		var oldestKey any
+		var oldestExpiry time.Time
+
+		c.entries.Range(func(key, value any) bool {
+			entry := value.(*cacheEntry)
+			if oldestKey == nil || entry.expiresAt.Before(oldestExpiry) {
+				oldestKey = key
+				oldestExpiry = entry.expiresAt
+			}
+			return true
+		})
+
+		if oldestKey != nil {
+			c.entries.Delete(oldestKey)
+		}
+		count--
+	}
 }

--- a/token_introspection/cache.go
+++ b/token_introspection/cache.go
@@ -45,6 +45,9 @@ type InMemoryCacheOption func(*inMemoryCacheConfig)
 // When exceeded on Set, the entry with the earliest expiration is evicted.
 // Default: 0 (unlimited).
 func WithMaxEntries(n int) InMemoryCacheOption {
+	if n < 0 {
+		n = 0
+	}
 	return func(c *inMemoryCacheConfig) {
 		c.maxEntries = n
 	}
@@ -80,7 +83,9 @@ func NewInMemoryCache(ctx context.Context, ttl time.Duration, opts ...InMemoryCa
 		maxEntries: cfg.maxEntries,
 	}
 
-	go c.sweepLoop(ctx, cfg.sweepInterval)
+	if cfg.sweepInterval > 0 {
+		go c.sweepLoop(ctx, cfg.sweepInterval)
+	}
 
 	return c
 }

--- a/token_introspection/cache_test.go
+++ b/token_introspection/cache_test.go
@@ -16,6 +16,7 @@ package tokenintrospection
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -193,11 +194,11 @@ func TestInMemoryCache_MaxEntriesZeroUnlimited(t *testing.T) {
 	cache := NewInMemoryCache(ctx, 1*time.Minute)
 
 	for i := 0; i < 100; i++ {
-		cache.Set("key"+string(rune('a'+i)), &IntrospectionResult{Subject: "user"})
+		cache.Set(fmt.Sprintf("key%d", i), &IntrospectionResult{Subject: "user"})
 	}
 
 	// All entries should exist
-	got, ok := cache.Get("keya")
+	got, ok := cache.Get("key0")
 	if !ok || got.Subject != "user" {
 		t.Error("expected all entries to exist with unlimited cache")
 	}

--- a/token_introspection/cache_test.go
+++ b/token_introspection/cache_test.go
@@ -15,13 +15,14 @@
 package tokenintrospection
 
 import (
+	"context"
 	"testing"
 	"time"
 )
 
 // Verify basic Set and Get.
 func TestInMemoryCache_SetGet(t *testing.T) {
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 	result := &IntrospectionResult{Subject: "user-1"}
 
 	cache.Set("key1", result)
@@ -37,7 +38,7 @@ func TestInMemoryCache_SetGet(t *testing.T) {
 
 // Verify that expired entries return a miss.
 func TestInMemoryCache_Expiry(t *testing.T) {
-	cache := NewInMemoryCache(1 * time.Millisecond)
+	cache := NewInMemoryCache(context.Background(), 1*time.Millisecond)
 	cache.Set("key1", &IntrospectionResult{Subject: "user-1"})
 
 	time.Sleep(5 * time.Millisecond)
@@ -50,7 +51,7 @@ func TestInMemoryCache_Expiry(t *testing.T) {
 
 // Verify that Get returns miss for unknown keys.
 func TestInMemoryCache_Miss(t *testing.T) {
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 
 	_, ok := cache.Get("nonexistent")
 	if ok {
@@ -60,7 +61,7 @@ func TestInMemoryCache_Miss(t *testing.T) {
 
 // Verify that ExpiresAt shorter than TTL bounds the cache entry lifetime.
 func TestInMemoryCache_ExpiresAtBoundsEntry(t *testing.T) {
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 	cache.Set("key1", &IntrospectionResult{
 		Subject:   "user-1",
 		ExpiresAt: time.Now().Add(1 * time.Millisecond),
@@ -76,7 +77,7 @@ func TestInMemoryCache_ExpiresAtBoundsEntry(t *testing.T) {
 
 // Verify that keys with different scheme prefixes don't collide.
 func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 
 	cache.Set("bearer:token-abc", &IntrospectionResult{Subject: "bearer-user"})
 	cache.Set("basic:token-abc", &IntrospectionResult{Subject: "basic-user"})
@@ -89,5 +90,99 @@ func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
 	got2, ok := cache.Get("basic:token-abc")
 	if !ok || got2.Subject != "basic-user" {
 		t.Errorf("basic entry = %v, want basic-user", got2)
+	}
+}
+
+// Verify that background sweep removes expired entries.
+func TestInMemoryCache_SweepRemovesExpired(t *testing.T) {
+	cache := NewInMemoryCache(context.Background(), 1*time.Millisecond,
+		WithSweepInterval(2*time.Millisecond),
+	)
+
+	cache.Set("key1", &IntrospectionResult{Subject: "user-1"})
+
+	// Wait for entry to expire and sweep to run
+	time.Sleep(10 * time.Millisecond)
+
+	_, ok := cache.Get("key1")
+	if ok {
+		t.Error("expected cache miss after sweep")
+	}
+}
+
+// Verify that sweep stops when context is cancelled.
+func TestInMemoryCache_SweepStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cache := NewInMemoryCache(ctx, 1*time.Minute,
+		WithSweepInterval(1*time.Millisecond),
+	)
+
+	cache.Set("key1", &IntrospectionResult{Subject: "user-1"})
+
+	// Cancel context — sweep should stop
+	cancel()
+	time.Sleep(5 * time.Millisecond)
+
+	// Entry should still be accessible (not expired, sweep stopped)
+	got, ok := cache.Get("key1")
+	if !ok {
+		t.Fatal("expected cache hit — entry is not expired")
+	}
+	if got.Subject != "user-1" {
+		t.Errorf("Subject = %q, want %q", got.Subject, "user-1")
+	}
+}
+
+// Verify that max entries evicts the entry with earliest expiration.
+func TestInMemoryCache_MaxEntries(t *testing.T) {
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute,
+		WithMaxEntries(2),
+	)
+
+	// Entry 1 expires soonest (short TTL token)
+	cache.Set("key1", &IntrospectionResult{
+		Subject:   "user-1",
+		ExpiresAt: time.Now().Add(1 * time.Second),
+	})
+	// Entry 2 expires later
+	cache.Set("key2", &IntrospectionResult{
+		Subject:   "user-2",
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	})
+	// Entry 3 triggers eviction — key1 should be evicted (earliest expiry)
+	cache.Set("key3", &IntrospectionResult{
+		Subject:   "user-3",
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	})
+
+	_, ok1 := cache.Get("key1")
+	if ok1 {
+		t.Error("expected key1 to be evicted (earliest expiration)")
+	}
+
+	_, ok2 := cache.Get("key2")
+	if !ok2 {
+		t.Error("expected key2 to still exist")
+	}
+
+	_, ok3 := cache.Get("key3")
+	if !ok3 {
+		t.Error("expected key3 to still exist")
+	}
+}
+
+// Verify that maxEntries=0 means unlimited (default).
+func TestInMemoryCache_MaxEntriesZeroUnlimited(t *testing.T) {
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+
+	for i := 0; i < 100; i++ {
+		cache.Set("key"+string(rune('a'+i)), &IntrospectionResult{Subject: "user"})
+	}
+
+	// All entries should exist
+	got, ok := cache.Get("keya")
+	if !ok || got.Subject != "user" {
+		t.Error("expected all entries to exist with unlimited cache")
 	}
 }

--- a/token_introspection/cache_test.go
+++ b/token_introspection/cache_test.go
@@ -22,7 +22,9 @@ import (
 
 // Verify basic Set and Get.
 func TestInMemoryCache_SetGet(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute)
 	result := &IntrospectionResult{Subject: "user-1"}
 
 	cache.Set("key1", result)
@@ -38,7 +40,9 @@ func TestInMemoryCache_SetGet(t *testing.T) {
 
 // Verify that expired entries return a miss.
 func TestInMemoryCache_Expiry(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Millisecond)
 	cache.Set("key1", &IntrospectionResult{Subject: "user-1"})
 
 	time.Sleep(5 * time.Millisecond)
@@ -51,7 +55,9 @@ func TestInMemoryCache_Expiry(t *testing.T) {
 
 // Verify that Get returns miss for unknown keys.
 func TestInMemoryCache_Miss(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute)
 
 	_, ok := cache.Get("nonexistent")
 	if ok {
@@ -61,7 +67,9 @@ func TestInMemoryCache_Miss(t *testing.T) {
 
 // Verify that ExpiresAt shorter than TTL bounds the cache entry lifetime.
 func TestInMemoryCache_ExpiresAtBoundsEntry(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute)
 	cache.Set("key1", &IntrospectionResult{
 		Subject:   "user-1",
 		ExpiresAt: time.Now().Add(1 * time.Millisecond),
@@ -77,7 +85,9 @@ func TestInMemoryCache_ExpiresAtBoundsEntry(t *testing.T) {
 
 // Verify that keys with different scheme prefixes don't collide.
 func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute)
 
 	cache.Set("bearer:token-abc", &IntrospectionResult{Subject: "bearer-user"})
 	cache.Set("basic:token-abc", &IntrospectionResult{Subject: "basic-user"})
@@ -95,7 +105,9 @@ func TestInMemoryCache_SharedAcrossSchemes(t *testing.T) {
 
 // Verify that background sweep removes expired entries.
 func TestInMemoryCache_SweepRemovesExpired(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Millisecond,
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Millisecond,
 		WithSweepInterval(2*time.Millisecond),
 	)
 
@@ -136,7 +148,9 @@ func TestInMemoryCache_SweepStopsOnCancel(t *testing.T) {
 
 // Verify that max entries evicts the entry with earliest expiration.
 func TestInMemoryCache_MaxEntries(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute,
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute,
 		WithMaxEntries(2),
 	)
 
@@ -174,7 +188,9 @@ func TestInMemoryCache_MaxEntries(t *testing.T) {
 
 // Verify that maxEntries=0 means unlimited (default).
 func TestInMemoryCache_MaxEntriesZeroUnlimited(t *testing.T) {
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache := NewInMemoryCache(ctx, 1*time.Minute)
 
 	for i := 0; i < 100; i++ {
 		cache.Set("key"+string(rune('a'+i)), &IntrospectionResult{Subject: "user"})

--- a/token_introspection/doc.go
+++ b/token_introspection/doc.go
@@ -29,7 +29,7 @@
 //	    grpc.ChainUnaryInterceptor(
 //	        tokenintrospection.Interceptor(
 //	            tokenintrospection.WithIntrospector(rfc7662),
-//	            tokenintrospection.WithCache(tokenintrospection.NewInMemoryCache(ctx, 30 * time.Second)),
+//	            tokenintrospection.WithCache(tokenintrospection.NewInMemoryCache(context.Background(), 30 * time.Second)),
 //	        ),
 //	    ),
 //	)

--- a/token_introspection/doc.go
+++ b/token_introspection/doc.go
@@ -29,7 +29,7 @@
 //	    grpc.ChainUnaryInterceptor(
 //	        tokenintrospection.Interceptor(
 //	            tokenintrospection.WithIntrospector(rfc7662),
-//	            tokenintrospection.WithCache(tokenintrospection.NewInMemoryCache(30 * time.Second)),
+//	            tokenintrospection.WithCache(tokenintrospection.NewInMemoryCache(ctx, 30 * time.Second)),
 //	        ),
 //	    ),
 //	)

--- a/token_introspection/interceptor_test.go
+++ b/token_introspection/interceptor_test.go
@@ -246,7 +246,7 @@ func TestInterceptor_CacheHit(t *testing.T) {
 		return &IntrospectionResult{Subject: "cached-user"}, nil
 	})
 
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
@@ -274,7 +274,7 @@ func TestInterceptor_CacheMiss(t *testing.T) {
 		return &IntrospectionResult{Subject: "user"}, nil
 	})
 
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
@@ -296,7 +296,7 @@ func TestInterceptor_CacheErrorNotCached(t *testing.T) {
 		return nil, status.Error(codes.Unauthenticated, "invalid")
 	})
 
-	cache := NewInMemoryCache(1 * time.Minute)
+	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }

--- a/token_introspection/interceptor_test.go
+++ b/token_introspection/interceptor_test.go
@@ -246,7 +246,9 @@ func TestInterceptor_CacheHit(t *testing.T) {
 		return &IntrospectionResult{Subject: "cached-user"}, nil
 	})
 
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	cacheCtx, cacheCancel := context.WithCancel(context.Background())
+	defer cacheCancel()
+	cache := NewInMemoryCache(cacheCtx, 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
@@ -274,7 +276,9 @@ func TestInterceptor_CacheMiss(t *testing.T) {
 		return &IntrospectionResult{Subject: "user"}, nil
 	})
 
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	cacheCtx, cacheCancel := context.WithCancel(context.Background())
+	defer cacheCancel()
+	cache := NewInMemoryCache(cacheCtx, 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }
@@ -296,7 +300,9 @@ func TestInterceptor_CacheErrorNotCached(t *testing.T) {
 		return nil, status.Error(codes.Unauthenticated, "invalid")
 	})
 
-	cache := NewInMemoryCache(context.Background(), 1*time.Minute)
+	cacheCtx, cacheCancel := context.WithCancel(context.Background())
+	defer cacheCancel()
+	cache := NewInMemoryCache(cacheCtx, 1*time.Minute)
 	interceptor := Interceptor(WithIntrospector(introspector), WithCache(cache))
 
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) { return nil, nil }


### PR DESCRIPTION
## Summary

- Add `context.Context` to `NewInMemoryCache` for goroutine lifecycle management
- Add `WithMaxEntries(n)` option — evicts entry with earliest expiration when exceeded
- Add `WithSweepInterval(d)` option — background goroutine removes expired entries periodically
- Update all documentation and usage examples

## Test plan

- [ ] 41 tests pass including 4 new cache tests (`go test ./... -count=1 -race`)
- [ ] `go vet` clean
- [ ] Other modules unaffected

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)