### PR TITLE
feat: RFC 7662 compliance for introspection request format and auth

### DIFF
--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -93,8 +93,14 @@ func WithMaxResponseBodySize(size int64) RFC7662Option {
 // WithClientCredentials sets Basic authentication for the introspection endpoint.
 // This is the recommended mode for production (RFC 7662 §2.1).
 func WithClientCredentials(clientID, clientSecret string) RFC7662Option {
+	if clientID == "" {
+		panic("clientID must not be empty")
+	}
+	if clientSecret == "" {
+		panic("clientSecret must not be empty")
+	}
+	encoded := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
 	return func(c *rfc7662Config) {
-		encoded := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
 		c.authFunc = func(_ string) (string, string) {
 			return "Authorization", "Basic " + encoded
 		}
@@ -103,6 +109,9 @@ func WithClientCredentials(clientID, clientSecret string) RFC7662Option {
 
 // WithBearerAuth sets a fixed service-level Bearer token for the introspection endpoint.
 func WithBearerAuth(token string) RFC7662Option {
+	if token == "" {
+		panic("token must not be empty")
+	}
 	return func(c *rfc7662Config) {
 		c.authFunc = func(_ string) (string, string) {
 			return "Authorization", "Bearer " + token

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -103,7 +103,7 @@ func WithClientCredentials(clientID, clientSecret string) RFC7662Option {
 	if clientSecret == "" {
 		panic("clientSecret must not be empty")
 	}
-	encoded := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
+	encoded := base64.StdEncoding.EncodeToString([]byte(url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)))
 	return func(c *rfc7662Config) {
 		c.authFunc = func(_ string) (string, string) {
 			return "Authorization", "Basic " + encoded

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -92,6 +92,10 @@ func WithMaxResponseBodySize(size int64) RFC7662Option {
 
 // WithClientCredentials sets Basic authentication for the introspection endpoint.
 // This is the recommended mode for production (RFC 7662 §2.1).
+//
+// Auth options (WithClientCredentials, WithBearerAuth, WithSelfIntrospect) are
+// mutually exclusive. If multiple are provided, the last one wins (standard
+// functional options behavior).
 func WithClientCredentials(clientID, clientSecret string) RFC7662Option {
 	if clientID == "" {
 		panic("clientID must not be empty")

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -17,11 +17,13 @@ package tokenintrospection
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -34,12 +36,19 @@ const (
 	defaultMaxResponseBodySize = 1024 * 1024 // 1MB
 )
 
+// authFunc returns an HTTP header key/value pair for endpoint authentication.
+// The credential parameter is the token being inspected (used by WithSelfIntrospect).
+// If authFunc is nil, no Authorization header is sent.
+type authFunc func(credential string) (key, value string)
+
 type rfc7662Config struct {
 	timeout             time.Duration
 	maxResponseBodySize int64
 	logger              *slog.Logger
 	requestIDFunc       func(context.Context) string
 	requestIDHeaderKey  string
+	authFunc            authFunc
+	useJSONBody         bool
 }
 
 // RFC7662Option configures the RFC 7662 introspection backend.
@@ -81,6 +90,46 @@ func WithMaxResponseBodySize(size int64) RFC7662Option {
 	}
 }
 
+// WithClientCredentials sets Basic authentication for the introspection endpoint.
+// This is the recommended mode for production (RFC 7662 §2.1).
+func WithClientCredentials(clientID, clientSecret string) RFC7662Option {
+	return func(c *rfc7662Config) {
+		encoded := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
+		c.authFunc = func(_ string) (string, string) {
+			return "Authorization", "Basic " + encoded
+		}
+	}
+}
+
+// WithBearerAuth sets a fixed service-level Bearer token for the introspection endpoint.
+func WithBearerAuth(token string) RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.authFunc = func(_ string) (string, string) {
+			return "Authorization", "Bearer " + token
+		}
+	}
+}
+
+// WithSelfIntrospect forwards the inspected token as Bearer authentication.
+// This is the legacy behavior — the token being inspected is reused as the
+// endpoint credential. Suitable for internal networks where the introspection
+// endpoint trusts the caller implicitly.
+func WithSelfIntrospect() RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.authFunc = func(credential string) (string, string) {
+			return "Authorization", "Bearer " + credential
+		}
+	}
+}
+
+// WithJSONBody switches the request body format to application/json.
+// By default, the introspector uses application/x-www-form-urlencoded per RFC 7662 §2.1.
+func WithJSONBody() RFC7662Option {
+	return func(c *rfc7662Config) {
+		c.useJSONBody = true
+	}
+}
+
 // WithRFC7662LogLevel sets the log level for the RFC 7662 backend.
 func WithRFC7662LogLevel(level slog.Level) RFC7662Option {
 	return func(c *rfc7662Config) {
@@ -95,6 +144,8 @@ type rfc7662Introspector struct {
 	logger              *slog.Logger
 	requestIDFunc       func(context.Context) string
 	requestIDHeaderKey  string
+	authFunc            authFunc
+	useJSONBody         bool
 }
 
 // NewRFC7662Introspector creates an Introspector that calls an RFC 7662 compliant
@@ -126,6 +177,8 @@ func NewRFC7662Introspector(introspectURL string, opts ...RFC7662Option) (Intros
 		logger:              cfg.logger,
 		requestIDFunc:       cfg.requestIDFunc,
 		requestIDHeaderKey:  cfg.requestIDHeaderKey,
+		authFunc:            cfg.authFunc,
+		useJSONBody:         cfg.useJSONBody,
 	}, nil
 }
 
@@ -133,9 +186,18 @@ func (i *rfc7662Introspector) Scheme() string { return "bearer" }
 
 func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string) (*IntrospectionResult, error) {
 	// Build request body
-	reqBody, err := json.Marshal(map[string]string{"token": credential})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to marshal request body: %v", err)
+	var reqBody []byte
+	var contentType string
+	if i.useJSONBody {
+		var err error
+		reqBody, err = json.Marshal(map[string]string{"token": credential})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to marshal request body: %v", err)
+		}
+		contentType = "application/json"
+	} else {
+		reqBody = []byte(url.Values{"token": {credential}}.Encode())
+		contentType = "application/x-www-form-urlencoded"
 	}
 
 	// Create HTTP request
@@ -144,9 +206,14 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 		return nil, status.Errorf(codes.Internal, "failed to create request: %v", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+credential)
+
+	// Set endpoint authentication
+	if i.authFunc != nil {
+		key, value := i.authFunc(credential)
+		req.Header.Set(key, value)
+	}
 
 	// Forward request ID if configured
 	if i.requestIDFunc != nil {

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -454,6 +454,36 @@ func TestRFC7662_LegacyCompat(t *testing.T) {
 	}
 }
 
+// Verify WithClientCredentials panics on empty clientID.
+func TestWithClientCredentials_EmptyClientID_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty clientID")
+		}
+	}()
+	WithClientCredentials("", "secret")
+}
+
+// Verify WithClientCredentials panics on empty clientSecret.
+func TestWithClientCredentials_EmptyClientSecret_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty clientSecret")
+		}
+	}()
+	WithClientCredentials("client", "")
+}
+
+// Verify WithBearerAuth panics on empty token.
+func TestWithBearerAuth_EmptyToken_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for empty token")
+		}
+	}()
+	WithBearerAuth("")
+}
+
 // Verify empty URL returns error.
 func TestNewRFC7662Introspector_EmptyURL_ReturnsError(t *testing.T) {
 	_, err := NewRFC7662Introspector("")

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -399,6 +399,61 @@ func TestRFC7662_ScopesArrayPrecedence(t *testing.T) {
 	}
 }
 
+// Verify WithJSONBody sends application/json with {"token":"..."}.
+func TestRFC7662_WithJSONBody(t *testing.T) {
+	var capturedContentType string
+	var capturedBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithJSONBody())
+	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+
+	if capturedContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/json")
+	}
+	if capturedBody["token"] != "my-jwt-token" {
+		t.Errorf("body[token] = %q, want %q", capturedBody["token"], "my-jwt-token")
+	}
+}
+
+// Verify WithJSONBody + WithSelfIntrospect reproduces legacy behavior.
+func TestRFC7662_LegacyCompat(t *testing.T) {
+	var capturedContentType string
+	var capturedAuth string
+	var capturedBody map[string]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		capturedAuth = r.Header.Get("Authorization")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithJSONBody(), WithSelfIntrospect())
+	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+
+	if capturedContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/json")
+	}
+	if capturedAuth != "Bearer my-jwt-token" {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer my-jwt-token")
+	}
+	if capturedBody["token"] != "my-jwt-token" {
+		t.Errorf("body[token] = %q, want %q", capturedBody["token"], "my-jwt-token")
+	}
+}
+
 // Verify empty URL returns error.
 func TestNewRFC7662Introspector_EmptyURL_ReturnsError(t *testing.T) {
 	_, err := NewRFC7662Introspector("")

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -16,6 +16,7 @@ package tokenintrospection
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -25,6 +26,10 @@ import (
 
 	"google.golang.org/grpc/codes"
 )
+
+func base64Encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
 
 // Verify Scheme() returns "bearer".
 func TestRFC7662_Scheme(t *testing.T) {
@@ -221,12 +226,14 @@ func TestRFC7662_WithRequestIDHeaderKey(t *testing.T) {
 	}
 }
 
-// Verify the request body contains the token.
-func TestRFC7662_RequestBody(t *testing.T) {
-	var body map[string]string
+// Verify default body is application/x-www-form-urlencoded with token=<value>.
+func TestRFC7662_DefaultFormURLEncoded(t *testing.T) {
+	var capturedContentType string
+	var capturedBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
 		raw, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(raw, &body)
+		capturedBody = string(raw)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
@@ -236,13 +243,37 @@ func TestRFC7662_RequestBody(t *testing.T) {
 	ep, _ := NewRFC7662Introspector(server.URL)
 	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
 
-	if body["token"] != "my-jwt-token" {
-		t.Errorf("body[token] = %q, want %q", body["token"], "my-jwt-token")
+	if capturedContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/x-www-form-urlencoded")
+	}
+	if capturedBody != "token=my-jwt-token" {
+		t.Errorf("body = %q, want %q", capturedBody, "token=my-jwt-token")
 	}
 }
 
-// Verify Authorization: Bearer <token> is set on the request.
-func TestRFC7662_AuthorizationHeader(t *testing.T) {
+// Verify special characters in token are properly URL-encoded.
+func TestRFC7662_FormURLEncoded_SpecialChars(t *testing.T) {
+	var capturedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		capturedBody = string(raw)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	_, _ = ep.Introspect(context.Background(), "token+with=special&chars")
+
+	want := "token=token%2Bwith%3Dspecial%26chars"
+	if capturedBody != want {
+		t.Errorf("body = %q, want %q", capturedBody, want)
+	}
+}
+
+// Verify no Authorization header is sent by default.
+func TestRFC7662_DefaultNoAuthHeader(t *testing.T) {
 	var capturedAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedAuth = r.Header.Get("Authorization")
@@ -253,6 +284,64 @@ func TestRFC7662_AuthorizationHeader(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL)
+	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+
+	if capturedAuth != "" {
+		t.Errorf("Authorization = %q, want empty (no auth by default)", capturedAuth)
+	}
+}
+
+// Verify WithClientCredentials sends Basic auth.
+func TestRFC7662_WithClientCredentials(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithClientCredentials("my-client", "my-secret"))
+	_, _ = ep.Introspect(context.Background(), "some-token")
+
+	want := "Basic " + base64Encode("my-client:my-secret")
+	if capturedAuth != want {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, want)
+	}
+}
+
+// Verify WithBearerAuth sends a fixed Bearer token.
+func TestRFC7662_WithBearerAuth(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithBearerAuth("service-token-xyz"))
+	_, _ = ep.Introspect(context.Background(), "user-token")
+
+	if capturedAuth != "Bearer service-token-xyz" {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer service-token-xyz")
+	}
+}
+
+// Verify WithSelfIntrospect forwards the inspected token as Bearer.
+func TestRFC7662_WithSelfIntrospect(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithSelfIntrospect())
 	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
 
 	if capturedAuth != "Bearer my-jwt-token" {

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -241,7 +241,9 @@ func TestRFC7662_DefaultFormURLEncoded(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL)
-	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+	if _, err := ep.Introspect(context.Background(), "my-jwt-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedContentType != "application/x-www-form-urlencoded" {
 		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/x-www-form-urlencoded")
@@ -264,7 +266,9 @@ func TestRFC7662_FormURLEncoded_SpecialChars(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL)
-	_, _ = ep.Introspect(context.Background(), "token+with=special&chars")
+	if _, err := ep.Introspect(context.Background(), "token+with=special&chars"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	want := "token=token%2Bwith%3Dspecial%26chars"
 	if capturedBody != want {
@@ -284,14 +288,16 @@ func TestRFC7662_DefaultNoAuthHeader(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL)
-	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+	if _, err := ep.Introspect(context.Background(), "my-jwt-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedAuth != "" {
 		t.Errorf("Authorization = %q, want empty (no auth by default)", capturedAuth)
 	}
 }
 
-// Verify WithClientCredentials sends Basic auth.
+// Verify WithClientCredentials sends Basic auth with RFC 6749 §2.3.1 encoding.
 func TestRFC7662_WithClientCredentials(t *testing.T) {
 	var capturedAuth string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -303,9 +309,35 @@ func TestRFC7662_WithClientCredentials(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL, WithClientCredentials("my-client", "my-secret"))
-	_, _ = ep.Introspect(context.Background(), "some-token")
+	if _, err := ep.Introspect(context.Background(), "some-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
+	// clientID and clientSecret are URL-encoded per RFC 6749 §2.3.1 before base64
 	want := "Basic " + base64Encode("my-client:my-secret")
+	if capturedAuth != want {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, want)
+	}
+}
+
+// Verify WithClientCredentials URL-encodes special characters per RFC 6749 §2.3.1.
+func TestRFC7662_WithClientCredentials_SpecialChars(t *testing.T) {
+	var capturedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"active": true, "sub": "u"})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL, WithClientCredentials("client:id", "secret with spaces"))
+	if _, err := ep.Introspect(context.Background(), "token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// ':' → %3A, ' ' → '+' per url.QueryEscape
+	want := "Basic " + base64Encode("client%3Aid:secret+with+spaces")
 	if capturedAuth != want {
 		t.Errorf("Authorization = %q, want %q", capturedAuth, want)
 	}
@@ -323,7 +355,9 @@ func TestRFC7662_WithBearerAuth(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL, WithBearerAuth("service-token-xyz"))
-	_, _ = ep.Introspect(context.Background(), "user-token")
+	if _, err := ep.Introspect(context.Background(), "user-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedAuth != "Bearer service-token-xyz" {
 		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer service-token-xyz")
@@ -342,7 +376,9 @@ func TestRFC7662_WithSelfIntrospect(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL, WithSelfIntrospect())
-	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+	if _, err := ep.Introspect(context.Background(), "my-jwt-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedAuth != "Bearer my-jwt-token" {
 		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer my-jwt-token")
@@ -414,7 +450,9 @@ func TestRFC7662_WithJSONBody(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL, WithJSONBody())
-	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+	if _, err := ep.Introspect(context.Background(), "my-jwt-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedContentType != "application/json" {
 		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/json")
@@ -441,7 +479,9 @@ func TestRFC7662_LegacyCompat(t *testing.T) {
 	defer server.Close()
 
 	ep, _ := NewRFC7662Introspector(server.URL, WithJSONBody(), WithSelfIntrospect())
-	_, _ = ep.Introspect(context.Background(), "my-jwt-token")
+	if _, err := ep.Introspect(context.Background(), "my-jwt-token"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if capturedContentType != "application/json" {
 		t.Errorf("Content-Type = %q, want %q", capturedContentType, "application/json")


### PR DESCRIPTION
## Summary

- Switch default request body to `application/x-www-form-urlencoded` per RFC 7662 §2.1
- Remove implicit `Authorization: Bearer <inspected-token>` header — callers must explicitly choose an auth method
- Add endpoint authentication options: `WithClientCredentials`, `WithBearerAuth`, `WithSelfIntrospect`
- Add `WithJSONBody()` for backward compatibility with existing auth.provider API
- `WithJSONBody()` + `WithSelfIntrospect()` reproduces legacy behavior

Closes #13

## Test plan
- [x] Default form-urlencoded body format verified
- [x] Special character URL encoding verified
- [x] No auth header by default
- [x] WithClientCredentials sends Basic auth
- [x] WithBearerAuth sends fixed Bearer token
- [x] WithSelfIntrospect forwards inspected token
- [x] WithJSONBody sends application/json
- [x] Legacy compat (WithJSONBody + WithSelfIntrospect) verified
- [x] All existing tests pass (scope parsing, claim mapping, request ID, error handling)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)