### PR TITLE
refactor(endpoint): unify request ID forwarding with WithRequestIDFunc pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/superpowers/
+.worktrees/

--- a/policy_verification/endpoint/example_test.go
+++ b/policy_verification/endpoint/example_test.go
@@ -93,6 +93,27 @@ func ExampleNewStaticEndpoint() {
 	// Output: verifier created
 }
 
+func ExampleNewRESTEndpoint_withRequestIDFunc() {
+	// Use with request_tracking module:
+	//   endpoint.WithRequestIDFunc(rt.RequestIDFromContext)
+	//
+	// Or use a custom extraction function:
+	verifier, err := endpoint.NewRESTEndpoint(
+		"http://auth-service:8080",
+		endpoint.WithRequestIDFunc(func(ctx context.Context) string {
+			// Extract request ID from your preferred source.
+			return ""
+		}),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("verifier created")
+	_ = verifier
+	// Output: verifier created
+}
+
 func ExampleNewCedarAgentEndpoint_customPrefixes() {
 	verifier, err := endpoint.NewCedarAgentEndpoint(
 		"http://cedar-agent:8180",

--- a/policy_verification/endpoint/example_test.go
+++ b/policy_verification/endpoint/example_test.go
@@ -100,9 +100,10 @@ func ExampleNewRESTEndpoint_withRequestIDFunc() {
 	// Or use a custom extraction function:
 	verifier, err := endpoint.NewRESTEndpoint(
 		"http://auth-service:8080",
+		// Returning a non-empty value enables request ID header forwarding.
+		// Returning "" disables forwarding for that request.
 		endpoint.WithRequestIDFunc(func(ctx context.Context) string {
-			// Extract request ID from your preferred source.
-			return ""
+			return "sample-request-id"
 		}),
 	)
 	if err != nil {

--- a/policy_verification/endpoint/rest_cedar_agent.go
+++ b/policy_verification/endpoint/rest_cedar_agent.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -42,6 +40,7 @@ type cedarAgentBuildConfig struct {
 	actionPrefix         string
 	resourcePrefix       string
 	principalResolver    func(ctx context.Context, token string) string
+	requestIDFunc        func(context.Context) string
 }
 
 // CedarAgentOption configures the Cedar agent REST endpoint.
@@ -101,9 +100,19 @@ func WithCedarAgentResourcePrefix(prefix string) CedarAgentOption {
 
 // WithCedarAgentRequestIDHeaderKey sets the HTTP header key for forwarding the request ID
 // to the Cedar agent. Default is "x-request-id". Set to empty string to disable forwarding.
+// Only used when WithCedarAgentRequestIDFunc is also set.
 func WithCedarAgentRequestIDHeaderKey(key string) CedarAgentOption {
 	return func(c *cedarAgentBuildConfig) {
 		c.requestIDHeaderKey = key
+	}
+}
+
+// WithCedarAgentRequestIDFunc sets a function to extract the request ID from the context
+// for forwarding to the Cedar agent as a header.
+// If not set, no request ID is extracted and header forwarding is skipped.
+func WithCedarAgentRequestIDFunc(fn func(context.Context) string) CedarAgentOption {
+	return func(c *cedarAgentBuildConfig) {
+		c.requestIDFunc = fn
 	}
 }
 
@@ -129,6 +138,7 @@ type restCedarAgentEndpoint struct {
 	actionPrefix         string
 	resourcePrefix       string
 	principalResolver    func(ctx context.Context, token string) string
+	requestIDFunc        func(context.Context) string
 }
 
 // cedarAgentRequest is the JSON body sent to the Cedar agent's is_authorized API.
@@ -193,6 +203,7 @@ func NewCedarAgentEndpoint(baseURL string, opts ...CedarAgentOption) (VerifierEn
 		actionPrefix:        cfg.actionPrefix,
 		resourcePrefix:      cfg.resourcePrefix,
 		principalResolver:   cfg.principalResolver,
+		requestIDFunc:       cfg.requestIDFunc,
 	}, nil
 }
 
@@ -227,7 +238,10 @@ func (e *restCedarAgentEndpoint) Verify(ctx context.Context, resource, action st
 		return status.Errorf(codes.Internal, "failed to create Cedar agent request: %v", err)
 	}
 
-	requestID := rt.RequestIDFromContext(ctx)
+	var requestID string
+	if e.requestIDFunc != nil {
+		requestID = e.requestIDFunc(ctx)
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/policy_verification/endpoint/rest_cedar_agent.go
+++ b/policy_verification/endpoint/rest_cedar_agent.go
@@ -238,16 +238,15 @@ func (e *restCedarAgentEndpoint) Verify(ctx context.Context, resource, action st
 		return status.Errorf(codes.Internal, "failed to create Cedar agent request: %v", err)
 	}
 
-	var requestID string
-	if e.requestIDFunc != nil {
-		requestID = e.requestIDFunc(ctx)
-	}
-
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	if e.requestIDHeaderKey != "" && requestID != "" {
-		req.Header.Set(e.requestIDHeaderKey, requestID)
+	var requestID string
+	if e.requestIDHeaderKey != "" && e.requestIDFunc != nil {
+		if id := e.requestIDFunc(ctx); id != "" {
+			requestID = id
+			req.Header.Set(e.requestIDHeaderKey, id)
+		}
 	}
 
 	// Send the request.

--- a/policy_verification/endpoint/rest_cedar_agent_test.go
+++ b/policy_verification/endpoint/rest_cedar_agent_test.go
@@ -25,10 +25,7 @@ import (
 	"testing"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 )
 
 // --- NewCedarAgentEndpoint constructor tests ---
@@ -342,13 +339,14 @@ func TestCedarVerify_WithRequestIDHeaderKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep := newTestCedarAgentEndpoint(t, server.URL, WithCedarAgentRequestIDHeaderKey("X-Trace-Id"))
+	ep := newTestCedarAgentEndpoint(t, server.URL,
+		WithCedarAgentRequestIDHeaderKey("X-Trace-Id"),
+		WithCedarAgentRequestIDFunc(func(ctx context.Context) string {
+			return "cedar-custom-456"
+		}),
+	)
 
-	md := metadata.Pairs("authorization", "Bearer token")
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-	ctx = rt.WithRequestID(ctx, "cedar-custom-456")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -370,12 +368,42 @@ func TestCedarVerify_WithRequestIDHeaderKey_Empty_DisablesForwarding(t *testing.
 	}))
 	defer server.Close()
 
-	ep := newTestCedarAgentEndpoint(t, server.URL, WithCedarAgentRequestIDHeaderKey(""))
+	ep := newTestCedarAgentEndpoint(t, server.URL,
+		WithCedarAgentRequestIDHeaderKey(""),
+		WithCedarAgentRequestIDFunc(func(ctx context.Context) string {
+			return "should-not-forward"
+		}),
+	)
 
-	ctx := ctxWithBearerToken("token")
-	ctx = rt.WithRequestID(ctx, "should-not-forward")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestCedarVerify_WithRequestIDFunc verifies that a custom function is used to extract the request ID.
+func TestCedarVerify_WithRequestIDFunc(t *testing.T) {
+	var capturedRequestID string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestID = r.Header.Get("x-request-id")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"decision":"Allow"}`))
+	}))
+	defer server.Close()
+
+	ep, err := NewCedarAgentEndpoint(server.URL, WithCedarAgentRequestIDFunc(func(ctx context.Context) string {
+		return "cedar-func-injected-id"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedRequestID != "cedar-func-injected-id" {
+		t.Errorf("x-request-id = %q, want %q", capturedRequestID, "cedar-func-injected-id")
 	}
 }

--- a/policy_verification/endpoint/rest_o3_policy_verifier.go
+++ b/policy_verification/endpoint/rest_o3_policy_verifier.go
@@ -189,17 +189,16 @@ func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, act
 		return status.Errorf(codes.Internal, "failed to create request: %v", err)
 	}
 
-	var requestID string
-	if e.requestIDFunc != nil {
-		requestID = e.requestIDFunc(ctx)
-	}
-
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", tok.TokenType+" "+tok.Value)
 
-	if e.requestIDHeaderKey != "" && requestID != "" {
-		req.Header.Set(e.requestIDHeaderKey, requestID)
+	var requestID string
+	if e.requestIDHeaderKey != "" && e.requestIDFunc != nil {
+		if id := e.requestIDFunc(ctx); id != "" {
+			requestID = id
+			req.Header.Set(e.requestIDHeaderKey, id)
+		}
 	}
 
 	// --- リクエスト送信 ---------------------------------------------------

--- a/policy_verification/endpoint/rest_o3_policy_verifier.go
+++ b/policy_verification/endpoint/rest_o3_policy_verifier.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -44,6 +42,7 @@ type buildConfig struct {
 	maxResponseBodySize  int64
 	logger               *slog.Logger
 	requestIDHeaderKey   string
+	requestIDFunc        func(context.Context) string
 }
 
 // Option はo3 REST エンドポイントの設定オプション
@@ -78,10 +77,19 @@ func WithLogLevel(level slog.Level) Option {
 
 // WithRequestIDHeaderKey sets the HTTP header key for forwarding the request ID
 // to the authorization server. Default is "x-request-id". Set to empty string to
-// disable forwarding.
+// disable forwarding. Only used when WithRequestIDFunc is also set.
 func WithRequestIDHeaderKey(key string) Option {
 	return func(c *buildConfig) {
 		c.requestIDHeaderKey = key
+	}
+}
+
+// WithRequestIDFunc sets a function to extract the request ID from the context
+// for forwarding to the authorization server as a header.
+// If not set, no request ID is extracted and header forwarding is skipped.
+func WithRequestIDFunc(fn func(context.Context) string) Option {
+	return func(c *buildConfig) {
+		c.requestIDFunc = fn
 	}
 }
 
@@ -92,6 +100,7 @@ type restO3PolicyVerifierEndpoint struct {
 	maxResponseBodySize  int64
 	logger               *slog.Logger
 	requestIDHeaderKey   string
+	requestIDFunc        func(context.Context) string
 }
 
 // NewRESTEndpoint o3 REST 認可エンドポイントのコンストラクタ。
@@ -129,6 +138,7 @@ func NewRESTEndpoint(baseURL string, opts ...Option) (VerifierEndpoint, error) {
 		maxResponseBodySize: cfg.maxResponseBodySize,
 		logger:              cfg.logger,
 		requestIDHeaderKey:  cfg.requestIDHeaderKey,
+		requestIDFunc:       cfg.requestIDFunc,
 	}, nil
 }
 
@@ -179,7 +189,10 @@ func (e *restO3PolicyVerifierEndpoint) Verify(ctx context.Context, resource, act
 		return status.Errorf(codes.Internal, "failed to create request: %v", err)
 	}
 
-	requestID := rt.RequestIDFromContext(ctx)
+	var requestID string
+	if e.requestIDFunc != nil {
+		requestID = e.requestIDFunc(ctx)
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/policy_verification/endpoint/rest_o3_policy_verifier_test.go
+++ b/policy_verification/endpoint/rest_o3_policy_verifier_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -303,10 +301,15 @@ func TestVerify_RequestHeaders_SetCorrectly(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep := newTestEndpoint(t, server.URL)
+	ep, err := NewRESTEndpoint(server.URL, WithRequestIDFunc(func(ctx context.Context) string {
+		return "req-id-456"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	md := metadata.Pairs("authorization", "Bearer my-token")
 	ctx := metadata.NewIncomingContext(context.Background(), md)
-	ctx = rt.WithRequestID(ctx, "req-id-456")
 
 	if err := ep.Verify(ctx, "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -453,16 +456,17 @@ func TestVerify_WithRequestIDHeaderKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep, err := NewRESTEndpoint(server.URL, WithRequestIDHeaderKey("X-Correlation-Id"))
+	ep, err := NewRESTEndpoint(server.URL,
+		WithRequestIDHeaderKey("X-Correlation-Id"),
+		WithRequestIDFunc(func(ctx context.Context) string {
+			return "req-custom-789"
+		}),
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	md := metadata.Pairs("authorization", "Bearer my-token")
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-	ctx = rt.WithRequestID(ctx, "req-custom-789")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("my-token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -481,16 +485,44 @@ func TestVerify_WithRequestIDHeaderKey_Empty_DisablesForwarding(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep, err := NewRESTEndpoint(server.URL, WithRequestIDHeaderKey(""))
+	ep, err := NewRESTEndpoint(server.URL,
+		WithRequestIDHeaderKey(""),
+		WithRequestIDFunc(func(ctx context.Context) string {
+			return "should-not-forward"
+		}),
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := ctxWithBearerToken("token")
-	ctx = rt.WithRequestID(ctx, "should-not-forward")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestVerify_WithRequestIDFunc verifies that a custom function is used to extract the request ID.
+func TestVerify_WithRequestIDFunc(t *testing.T) {
+	var capturedRequestID string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestID = r.Header.Get("x-request-id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ep, err := NewRESTEndpoint(server.URL, WithRequestIDFunc(func(ctx context.Context) string {
+		return "func-injected-id"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedRequestID != "func-injected-id" {
+		t.Errorf("x-request-id = %q, want %q", capturedRequestID, "func-injected-id")
 	}
 }
 

--- a/policy_verification/endpoint/rest_opa.go
+++ b/policy_verification/endpoint/rest_opa.go
@@ -192,16 +192,15 @@ func (e *restOPAEndpoint) Verify(ctx context.Context, resource, action string) e
 		return status.Errorf(codes.Internal, "failed to create OPA request: %v", err)
 	}
 
-	var requestID string
-	if e.requestIDFunc != nil {
-		requestID = e.requestIDFunc(ctx)
-	}
-
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	if e.requestIDHeaderKey != "" && requestID != "" {
-		req.Header.Set(e.requestIDHeaderKey, requestID)
+	var requestID string
+	if e.requestIDHeaderKey != "" && e.requestIDFunc != nil {
+		if id := e.requestIDFunc(ctx); id != "" {
+			requestID = id
+			req.Header.Set(e.requestIDHeaderKey, id)
+		}
 	}
 
 	// Send the request.

--- a/policy_verification/endpoint/rest_opa.go
+++ b/policy_verification/endpoint/rest_opa.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -38,6 +36,7 @@ type opaBuildConfig struct {
 	maxResponseBodySize  int64
 	logger               *slog.Logger
 	requestIDHeaderKey   string
+	requestIDFunc        func(context.Context) string
 }
 
 // OPAOption configures the OPA REST endpoint.
@@ -73,9 +72,19 @@ func WithOPALogLevel(level slog.Level) OPAOption {
 
 // WithOPARequestIDHeaderKey sets the HTTP header key for forwarding the request ID
 // to OPA. Default is "x-request-id". Set to empty string to disable forwarding.
+// Only used when WithOPARequestIDFunc is also set.
 func WithOPARequestIDHeaderKey(key string) OPAOption {
 	return func(c *opaBuildConfig) {
 		c.requestIDHeaderKey = key
+	}
+}
+
+// WithOPARequestIDFunc sets a function to extract the request ID from the context
+// for forwarding to OPA as a header.
+// If not set, no request ID is extracted and header forwarding is skipped.
+func WithOPARequestIDFunc(fn func(context.Context) string) OPAOption {
+	return func(c *opaBuildConfig) {
+		c.requestIDFunc = fn
 	}
 }
 
@@ -86,6 +95,7 @@ type restOPAEndpoint struct {
 	maxResponseBodySize  int64
 	logger               *slog.Logger
 	requestIDHeaderKey   string
+	requestIDFunc        func(context.Context) string
 }
 
 // opaRequest is the JSON body sent to OPA's data API.
@@ -149,6 +159,7 @@ func NewOPAEndpoint(baseURL, policyPath string, opts ...OPAOption) (VerifierEndp
 		maxResponseBodySize: cfg.maxResponseBodySize,
 		logger:              cfg.logger,
 		requestIDHeaderKey:  cfg.requestIDHeaderKey,
+		requestIDFunc:       cfg.requestIDFunc,
 	}, nil
 }
 
@@ -181,7 +192,10 @@ func (e *restOPAEndpoint) Verify(ctx context.Context, resource, action string) e
 		return status.Errorf(codes.Internal, "failed to create OPA request: %v", err)
 	}
 
-	requestID := rt.RequestIDFromContext(ctx)
+	var requestID string
+	if e.requestIDFunc != nil {
+		requestID = e.requestIDFunc(ctx)
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/policy_verification/endpoint/rest_opa_test.go
+++ b/policy_verification/endpoint/rest_opa_test.go
@@ -25,10 +25,7 @@ import (
 	"testing"
 	"time"
 
-	rt "github.com/o3co/grpc.authz/request_tracking"
-
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 )
 
 // --- NewOPAEndpoint constructor tests ---
@@ -289,12 +286,14 @@ func TestOPAVerify_RequestID_ForwardedWhenPresent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep := newTestOPAEndpoint(t, server.URL)
-	md := metadata.Pairs("authorization", "Bearer token-xyz")
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-	ctx = rt.WithRequestID(ctx, "req-abc-123")
+	ep, err := NewOPAEndpoint(server.URL, "authz/allow", WithOPARequestIDFunc(func(ctx context.Context) string {
+		return "req-abc-123"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token-xyz"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -318,21 +317,52 @@ func TestOPAVerify_WithRequestIDHeaderKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ep, err := NewOPAEndpoint(server.URL, "authz/allow", WithOPARequestIDHeaderKey("X-Correlation-Id"))
+	ep, err := NewOPAEndpoint(server.URL, "authz/allow",
+		WithOPARequestIDHeaderKey("X-Correlation-Id"),
+		WithOPARequestIDFunc(func(ctx context.Context) string {
+			return "opa-custom-789"
+		}),
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	md := metadata.Pairs("authorization", "Bearer token")
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-	ctx = rt.WithRequestID(ctx, "opa-custom-789")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if capturedHeader != "opa-custom-789" {
 		t.Errorf("X-Correlation-Id = %q, want %q", capturedHeader, "opa-custom-789")
+	}
+}
+
+// TestOPAVerify_WithRequestIDFunc verifies that a custom function is used to extract the request ID.
+func TestOPAVerify_WithRequestIDFunc(t *testing.T) {
+	var capturedRequestID string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestID = r.Header.Get("x-request-id")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		result := true
+		resp := opaResponse{Result: &result}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ep, err := NewOPAEndpoint(server.URL, "authz/allow", WithOPARequestIDFunc(func(ctx context.Context) string {
+		return "opa-func-injected-id"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedRequestID != "opa-func-injected-id" {
+		t.Errorf("x-request-id = %q, want %q", capturedRequestID, "opa-func-injected-id")
 	}
 }
 
@@ -351,15 +381,17 @@ func TestOPAVerify_WithRequestIDHeaderKey_Empty_DisablesForwarding(t *testing.T)
 	}))
 	defer server.Close()
 
-	ep, err := NewOPAEndpoint(server.URL, "authz/allow", WithOPARequestIDHeaderKey(""))
+	ep, err := NewOPAEndpoint(server.URL, "authz/allow",
+		WithOPARequestIDHeaderKey(""),
+		WithOPARequestIDFunc(func(ctx context.Context) string {
+			return "should-not-forward"
+		}),
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := ctxWithBearerToken("token")
-	ctx = rt.WithRequestID(ctx, "should-not-forward")
-
-	if err := ep.Verify(ctx, "posts", "read"); err != nil {
+	if err := ep.Verify(ctxWithBearerToken("token"), "posts", "read"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/policy_verification/endpoint/rest_opa_test.go
+++ b/policy_verification/endpoint/rest_opa_test.go
@@ -271,37 +271,6 @@ func TestOPAVerify_RequestBody_ContainsInputFields(t *testing.T) {
 	}
 }
 
-// TestOPAVerify_RequestID_ForwardedWhenPresent verifies that x-request-id is forwarded to OPA
-// when present in the context.
-func TestOPAVerify_RequestID_ForwardedWhenPresent(t *testing.T) {
-	var capturedRequestID string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedRequestID = r.Header.Get("x-request-id")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		result := true
-		resp := opaResponse{Result: &result}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	ep, err := NewOPAEndpoint(server.URL, "authz/allow", WithOPARequestIDFunc(func(ctx context.Context) string {
-		return "req-abc-123"
-	}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if err := ep.Verify(ctxWithBearerToken("token-xyz"), "posts", "read"); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if capturedRequestID != "req-abc-123" {
-		t.Errorf("x-request-id = %q, want %q", capturedRequestID, "req-abc-123")
-	}
-}
-
 // TestOPAVerify_WithRequestIDHeaderKey verifies that a custom header key is used
 // when WithOPARequestIDHeaderKey is set.
 func TestOPAVerify_WithRequestIDHeaderKey(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace direct `request_tracking.RequestIDFromContext(ctx)` calls in all three endpoint implementations (o3, OPA, Cedar Agent) with injected `WithRequestIDFunc` / `WithOPARequestIDFunc` / `WithCedarAgentRequestIDFunc` options
- Remove `request_tracking` import from `policy_verification/endpoint/` package entirely
- Add example test showing `WithRequestIDFunc` usage

This is a **breaking change**: users must now explicitly pass `WithRequestIDFunc(rt.RequestIDFromContext)` to enable request ID forwarding (previously automatic).

Closes #11

## Test plan

- [ ] All endpoint tests pass (`go test ./endpoint/ -v`) — 88 tests
- [ ] Full module tests pass (`go test ./... -v`)
- [ ] `grep -r "request_tracking" policy_verification/endpoint/` returns zero import matches
- [ ] Verify `WithRequestIDFunc` + custom header key combination works
- [ ] Verify nil `requestIDFunc` (default) disables header forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)