### PR TITLE
feat: remove scopes array support, add token_type to promoted fields

### DIFF
--- a/token_introspection/introspector.go
+++ b/token_introspection/introspector.go
@@ -40,5 +40,6 @@ type IntrospectionResult struct {
 	Subject   string         // sub — the authenticated user/entity
 	Scopes    []string       // granted scopes
 	ExpiresAt time.Time      // expiration (zero value if not set)
-	Claims    map[string]any // additional claims (aud, iss, client, user, etc.)
+	TokenType string         // token_type — e.g. "at+jwt", "rt+jwt"
+	Claims    map[string]any // additional claims (aud, iss, azp, etc.)
 }

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -292,6 +292,11 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 		result.ExpiresAt = time.Unix(int64(exp), 0).UTC()
 	}
 
+	// TokenType
+	if tt, ok := raw["token_type"].(string); ok {
+		result.TokenType = tt
+	}
+
 	// Remaining claims (exclude promoted fields)
 	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "exp": true, "token_type": true}
 	for k, v := range raw {

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -282,18 +282,8 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 		result.Subject = sub
 	}
 
-	// Scopes: supports both RFC 7662 "scope" (space-separated string) and
-	// "scopes" (JSON array, used by auth.provider). If both are present,
-	// "scopes" takes precedence.
-	if scopesRaw, ok := raw["scopes"]; ok {
-		if arr, ok := scopesRaw.([]any); ok {
-			for _, s := range arr {
-				if str, ok := s.(string); ok {
-					result.Scopes = append(result.Scopes, str)
-				}
-			}
-		}
-	} else if scopeStr, ok := raw["scope"].(string); ok && scopeStr != "" {
+	// Scopes: RFC 7662 "scope" (space-separated string)
+	if scopeStr, ok := raw["scope"].(string); ok && scopeStr != "" {
 		result.Scopes = strings.Fields(scopeStr)
 	}
 
@@ -303,7 +293,7 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 	}
 
 	// Remaining claims (exclude promoted fields)
-	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "scopes": true, "exp": true}
+	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "exp": true, "token_type": true}
 	for k, v := range raw {
 		if !promoted[k] {
 			result.Claims[k] = v

--- a/token_introspection/rfc7662.go
+++ b/token_introspection/rfc7662.go
@@ -298,7 +298,7 @@ func (i *rfc7662Introspector) Introspect(ctx context.Context, credential string)
 	}
 
 	// Remaining claims (exclude promoted fields)
-	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "exp": true, "token_type": true}
+	promoted := map[string]bool{"active": true, "sub": true, "scope": true, "scopes": true, "exp": true, "token_type": true}
 	for k, v := range raw {
 		if !promoted[k] {
 			result.Claims[k] = v

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -146,6 +146,11 @@ func TestRFC7662_ClaimMapping(t *testing.T) {
 		t.Errorf("ExpiresAt = %v, want %v", result.ExpiresAt, wantExp)
 	}
 
+	// TokenType
+	if result.TokenType != "at+jwt" {
+		t.Errorf("TokenType = %q, want %q", result.TokenType, "at+jwt")
+	}
+
 	// Claims should contain aud, azp but NOT sub, scope, exp, active, token_type
 	if _, ok := result.Claims["sub"]; ok {
 		t.Error("Claims should not contain 'sub' (promoted to Subject)")

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -50,7 +50,7 @@ func TestRFC7662_ActiveTrue_ReturnsResult(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"active": true,
 			"sub":    "user-42",
-			"scopes": []string{"read", "write"},
+			"scope":  "read write",
 			"exp":    1735689600, // 2025-01-01T00:00:00Z
 			"iss":    "auth.provider",
 		})
@@ -114,18 +114,19 @@ func TestRFC7662_500_ReturnsInternal(t *testing.T) {
 	assertGRPCCode(t, err, codes.Internal)
 }
 
-// Verify claim mapping: sub, scopes, exp go to struct fields; rest to Claims.
+// Verify claim mapping: sub, scope, exp, token_type go to struct fields; rest to Claims.
 func TestRFC7662_ClaimMapping(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"active":  true,
-			"sub":     "user-99",
-			"scopes":  []string{"admin"},
-			"exp":     1735689600,
-			"aud":     "my-app",
-			"client":  map[string]any{"id": "client-1"},
+			"active":     true,
+			"sub":        "user-99",
+			"scope":      "admin",
+			"exp":        1735689600,
+			"token_type": "at+jwt",
+			"aud":        "my-app",
+			"azp":        "client-1",
 		})
 	}))
 	defer server.Close()
@@ -145,12 +146,12 @@ func TestRFC7662_ClaimMapping(t *testing.T) {
 		t.Errorf("ExpiresAt = %v, want %v", result.ExpiresAt, wantExp)
 	}
 
-	// Claims should contain aud, client but NOT sub, scopes, exp, active
+	// Claims should contain aud, azp but NOT sub, scope, exp, active, token_type
 	if _, ok := result.Claims["sub"]; ok {
 		t.Error("Claims should not contain 'sub' (promoted to Subject)")
 	}
-	if _, ok := result.Claims["scopes"]; ok {
-		t.Error("Claims should not contain 'scopes' (promoted to Scopes)")
+	if _, ok := result.Claims["scope"]; ok {
+		t.Error("Claims should not contain 'scope' (promoted to Scopes)")
 	}
 	if _, ok := result.Claims["exp"]; ok {
 		t.Error("Claims should not contain 'exp' (promoted to ExpiresAt)")
@@ -158,8 +159,14 @@ func TestRFC7662_ClaimMapping(t *testing.T) {
 	if _, ok := result.Claims["active"]; ok {
 		t.Error("Claims should not contain 'active'")
 	}
+	if _, ok := result.Claims["token_type"]; ok {
+		t.Error("Claims should not contain 'token_type' (promoted field)")
+	}
 	if result.Claims["aud"] != "my-app" {
 		t.Errorf("Claims[aud] = %v, want %q", result.Claims["aud"], "my-app")
+	}
+	if result.Claims["azp"] != "client-1" {
+		t.Errorf("Claims[azp] = %v, want %q", result.Claims["azp"], "client-1")
 	}
 }
 
@@ -408,30 +415,6 @@ func TestRFC7662_ScopeString(t *testing.T) {
 	}
 	if _, ok := result.Claims["scope"]; ok {
 		t.Error("Claims should not contain 'scope' (promoted to Scopes)")
-	}
-}
-
-// Verify "scopes" (array) takes precedence over "scope" (string) when both are present.
-func TestRFC7662_ScopesArrayPrecedence(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"active": true,
-			"sub":    "user-1",
-			"scope":  "read",
-			"scopes": []string{"write", "admin"},
-		})
-	}))
-	defer server.Close()
-
-	ep, _ := NewRFC7662Introspector(server.URL)
-	result, err := ep.Introspect(context.Background(), "token")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(result.Scopes) != 2 || result.Scopes[0] != "write" || result.Scopes[1] != "admin" {
-		t.Errorf("Scopes = %v, want [write admin] (scopes array should take precedence)", result.Scopes)
 	}
 }
 

--- a/token_introspection/rfc7662_test.go
+++ b/token_introspection/rfc7662_test.go
@@ -146,12 +146,17 @@ func TestRFC7662_ClaimMapping(t *testing.T) {
 		t.Errorf("ExpiresAt = %v, want %v", result.ExpiresAt, wantExp)
 	}
 
+	// Scopes
+	if len(result.Scopes) != 1 || result.Scopes[0] != "admin" {
+		t.Errorf("Scopes = %v, want [admin]", result.Scopes)
+	}
+
 	// TokenType
 	if result.TokenType != "at+jwt" {
 		t.Errorf("TokenType = %q, want %q", result.TokenType, "at+jwt")
 	}
 
-	// Claims should contain aud, azp but NOT sub, scope, exp, active, token_type
+	// Claims should contain aud, azp but NOT sub, scope, scopes, exp, active, token_type
 	if _, ok := result.Claims["sub"]; ok {
 		t.Error("Claims should not contain 'sub' (promoted to Subject)")
 	}
@@ -172,6 +177,37 @@ func TestRFC7662_ClaimMapping(t *testing.T) {
 	}
 	if result.Claims["azp"] != "client-1" {
 		t.Errorf("Claims[azp] = %v, want %q", result.Claims["azp"], "client-1")
+	}
+}
+
+// Legacy scopes array should be ignored (not leak into Claims), only scope string is used.
+func TestRFC7662_LegacyScopesArrayIgnored(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"active": true,
+			"sub":    "user-1",
+			"scope":  "read write",
+			"scopes": []string{"admin", "superuser"},
+		})
+	}))
+	defer server.Close()
+
+	ep, _ := NewRFC7662Introspector(server.URL)
+	result, err := ep.Introspect(context.Background(), "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Scopes should come from "scope" string, not "scopes" array
+	if len(result.Scopes) != 2 || result.Scopes[0] != "read" || result.Scopes[1] != "write" {
+		t.Errorf("Scopes = %v, want [read write]", result.Scopes)
+	}
+
+	// Legacy "scopes" should not leak into Claims
+	if _, ok := result.Claims["scopes"]; ok {
+		t.Error("Claims should not contain legacy 'scopes' array (promoted/dropped)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Update grpc.authz introspection for JWT claims standardization.

- Remove `scopes` (JSON array) support — only `scope` (space-separated string) per RFC 7662
- Add `token_type` to promoted fields (excluded from generic Claims map)
- Update test mock responses to use standard claims format

Related: o3co/auth.provider#20 (token format change)

## Test plan

- [x] All 23 token_introspection tests pass
- [x] scope string correctly parsed via strings.Fields
- [x] token_type excluded from Claims map

🤖 Generated with [Claude Code](https://claude.com/claude-code)